### PR TITLE
Fixed import error when trying to run tests

### DIFF
--- a/postcodeinfo/apps/postcode_api/downloaders/download_manager.py
+++ b/postcodeinfo/apps/postcode_api/downloaders/download_manager.py
@@ -44,7 +44,7 @@ class DownloadManager(object):
             count = 0
             for chunk in r.iter_content(chunk_size):
                 if content_length and count % 100 == 0:
-                    print '{0} bytes of {1}'.format(count*chunk_size
+                    print '{0} bytes of {1}'.format(count*chunk_size,
                                                     content_length)
                 count = count + 1
                 fd.write(chunk)

--- a/postcodeinfo/apps/postcode_api/importers/local_authorities_importer.py
+++ b/postcodeinfo/apps/postcode_api/importers/local_authorities_importer.py
@@ -21,8 +21,8 @@ class LocalAuthoritiesImporter(object):
 
         # all subject/object pairs which are related by a gssCode
         codes = self.graph.triples(
-            (None, URIRef("http://data.ordnancesurvey.co.uk/'\
-                    'ontology/admingeo/gssCode"), None))
+            (None, URIRef("http://data.ordnancesurvey.co.uk/"\
+                "ontology/admingeo/gssCode"), None))
         self.progress.start(filename)
 
         for code_tuple in codes:

--- a/postcodeinfo/apps/postcode_api/migrations/0003_populate_postcode_area.py
+++ b/postcodeinfo/apps/postcode_api/migrations/0003_populate_postcode_area.py
@@ -12,7 +12,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunSQL(
-            "UPDATE postcode_api_address"
+            "UPDATE postcode_api_address "
             "SET postcode_area = "
             "lower(split_part(postcode, ' ', 1));")
     ]

--- a/postcodeinfo/settings.py
+++ b/postcodeinfo/settings.py
@@ -16,7 +16,7 @@ BASE_DIR = os.path.dirname(PROJECT_ROOT)
 
 
 def root(*x):
-    os.path.join(PROJECT_ROOT, *x)
+    return os.path.join(PROJECT_ROOT, *x)
 
 sys.path.insert(0, root('apps'))
 


### PR DESCRIPTION
due to syntax error introduced in the PEP8 compliance commit.

Also fixed similar incorrect line continuation in local_authorities_importer that caused missing test data and resulted in failing tests