### PR TITLE
Fixed undefined variable 'filepath' in ZipExtractor

### DIFF
--- a/postcodeinfo/apps/postcode_api/tests/test_zip_extractor.py
+++ b/postcodeinfo/apps/postcode_api/tests/test_zip_extractor.py
@@ -1,0 +1,21 @@
+from django.test import TestCase
+
+from mock import patch, MagicMock
+
+from postcode_api.utils import ZipExtractor
+
+
+class ZipExtractorTestCase(TestCase):
+
+  @patch('zipfile.is_zipfile', return_value=True)
+  @patch('postcode_api.utils.ZipExtractor.unzip')
+  def test_that_when_given_a_zip_file_it_unzips_it(self, mock_unzip, mock_zip_file):
+    ZipExtractor('/my/test/file').unzip_if_needed('*')
+    mock_unzip.assertCalledWith('/my/test/file')
+
+
+  @patch('zipfile.is_zipfile', return_value=False)
+  @patch('postcode_api.utils.ZipExtractor.unzip')
+  def test_that_when_not_given_a_zip_file_it_does_not_unzip(self, mock_unzip, mock_zip_file):
+    rtn = ZipExtractor('/my/test/file').unzip_if_needed('*')    
+    assert not mock_unzip.called

--- a/postcodeinfo/apps/postcode_api/utils.py
+++ b/postcodeinfo/apps/postcode_api/utils.py
@@ -77,11 +77,12 @@ class ZipExtractor(object):
         self.filepath = filepath
 
     def unzip_if_needed(self, pattern):
-        if zipfile.is_zipfile(self.filepath):
+        if zipfile.is_zipfile(self.filepath) == True:
             print 'unzipping'
             return self.unzip(pattern)
         else:
-            return [filepath]
+            print 'not unzipping'
+            return [self.filepath]
 
     def unzip(self, pattern):
         extracted_files = []


### PR DESCRIPTION
Problem occurred when running import_addressbase_basic command or any of the others which call it (eg. download_and_import_all)
Also added test case