### PR TITLE
Fix staging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,6 @@ RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | 
 # APP_HOME, if you change this variable make sure you update the files in docker/ too
 ENV APP_HOME /srv/postcodeinfo
 
-RUN useradd -m -d ${APP_HOME} postcodeinfo
-
 RUN mkdir -p /var/log/gunicorn /var/log/nginx/postcodeinfo
 RUN touch /var/log/gunicorn/access.log /var/log/gunicorn/error.log
 RUN chown -R www-data:www-data /var/log/gunicorn && chmod -R g+s /var/log/gunicorn
@@ -33,7 +31,7 @@ VOLUME ["/var/log/nginx", "/var/log/gunicorn"]
 WORKDIR ${APP_HOME}
 ADD . ${APP_HOME}
 RUN rm -rf ${APP_HOME}/.git
-RUN chown -R postcodeinfo: ${APP_HOME}
+RUN chown -R www-data: ${APP_HOME}
 RUN cd ${APP_HOME} && pip install -r requirements.txt
 RUN ./manage.py collectstatic --noinput
 
@@ -50,7 +48,6 @@ RUN ./manage.py collectstatic --noinput
 #ENV DB_PORT 5432
 
 EXPOSE 80
-USER postcodeinfo
 
 # Use baseimage-docker's init process.
 CMD ["/sbin/my_init"]

--- a/docker/gunicorn.service
+++ b/docker/gunicorn.service
@@ -1,7 +1,8 @@
 #!/bin/bash
 cd /srv/postcodeinfo
-# Manage sync db
-python manage.py migrate --noinput >> /var/log/wsgi/db.scripts.log 2>&1
-python manage.py collectstatic --noinput >> /var/log/wsgi/db_scripts.log 2>&1
 
-exec /usr/local/bin/gunicorn -b unix:/tmp/gunicorn.sock -w4 postcodeinfo.wsgi:application --access-logfile /var/log/gunicorn/access.log --error-logfile /var/log/gunicorn/error.log --reload
+# Manage sync db
+chpst -uwww-data python manage.py migrate --noinput >> /var/log/gunicorn/migrate.log 2>&1
+chpst -uwww-data python manage.py collectstatic --noinput >> /var/log/gunicorn/collectstatic.log 2>&1
+
+exec chpst -uwww-data /usr/local/bin/gunicorn -b unix:/tmp/gunicorn.sock -w4 postcodeinfo.wsgi:application --access-logfile /var/log/gunicorn/access.log --error-logfile /var/log/gunicorn/error.log --reload

--- a/docker/uwsgi.service
+++ b/docker/uwsgi.service
@@ -1,7 +1,0 @@
-#!/bin/bash
-cd /srv/postcodeinfo
-# Manage sync db
-python manage.py migrate --noinput >> /var/log/wsgi/db_scripts.log 2>&1
-python manage.py collectstatic --noinput >> /var/log/wsgi/db_scripts.log 2>&1
-
-exec /usr/local/bin/uwsgi --ini /etc/wsgi/conf.d/postcodeinfo.ini


### PR DESCRIPTION
This PR will:
 - Remove wsgi as we're not using it any more (this makes things cleaner)
 - Use www-user instead of both www-user and the postcodeinfo user (this solves the permission issue when ./manage.py collectstatic is ran, as the folder was owned by postcode and executed by www-data)
 - Run the container as root (there's an issue when running everything as a regular user, mainly /sbin/my_init not being able to start. The app is still ran as an unprivileged user, but the instruction to do so is in runit rather than Dockerfile).