### PR TITLE
Keep import files cached on s3 and local disk and allow import from there

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ venv
 .venv
 .coverage
 htmlcov
+postcodeinfo/static
+

--- a/postcodeinfo/apps/postcode_api/downloaders/addressbase_basic_downloader.py
+++ b/postcodeinfo/apps/postcode_api/downloaders/addressbase_basic_downloader.py
@@ -1,7 +1,10 @@
+import ftplib
+import glob
 import os
 
 from postcode_api.downloaders.download_manager import DownloadManager
 from postcode_api.downloaders.ftp_download_manager import FTPDownloadManager
+from postcode_api.downloaders.s3_adapter import S3Adapter
 
 
 class AddressBaseBasicDownloader(object):
@@ -13,11 +16,28 @@ class AddressBaseBasicDownloader(object):
 
         self.download_manager.open(
             'osmmftp.os.uk', self._username(), self._password())
-        self.download_manager.ftp_client.cwd(self._source_dir())
 
-        return self.download_manager.download_all_if_needed('./*_csv.zip',
-                                                            local_dir,
-                                                            force)
+        try:
+            self.ftp_client().cwd(self._source_dir())
+            return self.download_manager.download_all_if_needed('./*_csv.zip',
+                                                                local_dir,
+                                                                force)
+        except ftplib.error_perm:
+            print 'FTP error - looking for local files'
+            # Ordnance Survey very kindly remove the files from our
+            # FTP area 21 days after they are first put there, despite
+            # there not being an update available for maybe another 2 months.
+            # So if we try to cd to our order dir
+            # and it's not there, we'll end up here.
+            # So, we then look for a load of csv.zip files in local_dir
+            # If there are csv.zip files locally, return them
+            # If not, look on s3.
+            # If they're on s3, download them and return the local paths.
+            # Otherwise FAIL
+            return self.local_files(local_dir) or self.files_from_s3(local_dir)
+
+    def ftp_client(self):
+        return self.download_manager.ftp_client
 
     def _username(self):
         username = os.environ.get('OS_FTP_USERNAME')
@@ -37,3 +57,19 @@ class AddressBaseBasicDownloader(object):
         # TODO - this is currently just the order number.
         # Make this dynamic based on the most recent directory?
         return os.environ.get('OS_FTP_ORDER_DIR', '../from-os/DCS0001654526/')
+
+    def local_files(self, local_dir):
+        files = glob.glob(os.path.join(local_dir, '*csv.zip'))
+        print 'found {num_files} files in {path} matching {pattern}'.format(num_files=len(files), path=local_dir, pattern='*csv.zip')
+        return files
+
+    def files_from_s3(self, local_dir):
+        files = []
+        s3 = S3Adapter()
+        s3_files = s3.bucket.list('AddressBase')
+        print 'found %i files in s3 matching %s' % (len(s3_files), 'AddressBase')
+        for key in s3_files:
+            print 'downloading %s' % key.name
+            files.append(s3.download(key, os.path.join(local_dir, key.name)))
+
+        return files

--- a/postcodeinfo/apps/postcode_api/downloaders/addressbase_basic_downloader.py
+++ b/postcodeinfo/apps/postcode_api/downloaders/addressbase_basic_downloader.py
@@ -1,5 +1,6 @@
 import ftplib
 import glob
+import logging
 import os
 
 from postcode_api.downloaders.download_manager import DownloadManager
@@ -23,7 +24,7 @@ class AddressBaseBasicDownloader(object):
                                                                 local_dir,
                                                                 force)
         except ftplib.error_perm:
-            print 'FTP error - looking for local files'
+            logging.warning('FTP error - looking for local files')
             # Ordnance Survey very kindly remove the files from our
             # FTP area 21 days after they are first put there, despite
             # there not being an update available for maybe another 2 months.
@@ -42,14 +43,14 @@ class AddressBaseBasicDownloader(object):
     def _username(self):
         username = os.environ.get('OS_FTP_USERNAME')
         if not username:
-            print 'OS_FTP_USERNAME not set!'
+            logging.warning('OS_FTP_USERNAME not set!')
 
         return username
 
     def _password(self):
         pwd = os.environ.get('OS_FTP_PASSWORD')
         if not pwd:
-            print 'OS_FTP_PASSWORD not set!'
+            logging.warning('OS_FTP_PASSWORD not set!')
 
         return pwd
 
@@ -60,16 +61,16 @@ class AddressBaseBasicDownloader(object):
 
     def local_files(self, local_dir):
         files = glob.glob(os.path.join(local_dir, '*csv.zip'))
-        print 'found {num_files} files in {path} matching {pattern}'.format(num_files=len(files), path=local_dir, pattern='*csv.zip')
+        logging.debug('found {num_files} files in {path} matching {pattern}'.format(num_files=len(files), path=local_dir, pattern='*csv.zip'))
         return files
 
     def files_from_s3(self, local_dir):
         files = []
         s3 = S3Adapter()
         s3_files = s3.bucket.list('AddressBase')
-        print 'found %i files in s3 matching %s' % (len(s3_files), 'AddressBase')
+        logging.debug( 'found %i files in s3 matching %s' % (len(s3_files), 'AddressBase') )
         for key in s3_files:
-            print 'downloading %s' % key.name
+            logging.debug( 'downloading %s' % key.name )
             files.append(s3.download(key, os.path.join(local_dir, key.name)))
 
         return files

--- a/postcodeinfo/apps/postcode_api/downloaders/download_manager.py
+++ b/postcodeinfo/apps/postcode_api/downloaders/download_manager.py
@@ -14,43 +14,45 @@ from postcode_api.downloaders.s3_adapter import S3Adapter
 
 class DownloadManager(object):
 
-    # Reasons for this workflow:
-    # 1) Ordnance Survey only gives us AddressBase files
-    #    for a limited time after updates are released (21 days)
-    #    then it removes the file from their FTP server
-    #
-    # 2) Our release process re-creates an entirely new
-    #    docker container each time, so we can't just
-    #    cache the files locally
     def retrieve(self, url, local_dir_path, force=False):
+        """
+        Reasons for this workflow:
+        1. Ordnance Survey only gives us AddressBase files
+           for a limited time after updates are released(21 days)
+           then it removes the file from their FTP server
+
+        2. Our release process re-creates an entirely new
+           docker container each time, so we can't just
+           cache the files locally
+        """
+
         remote_timestamp = self.get_last_modified(url)
         local_file_path = self.filename(local_dir_path, url)
 
         # if we have an up-to-date local copy, there's nothing to do
-        if not self.local_copy_up_to_date(local_file_path,
-                                          remote_timestamp):
+        if not self.local_copy_up_to_date(local_file_path, remote_timestamp):
             self.get_from_s3(local_file_path, url, remote_timestamp)
 
         return local_file_path
 
     def get_from_s3(self, local_file_path, url, remote_timestamp):
-        # if we *don't* have an up-to-date local copy
-        # do we have one on s3?
         s3 = self.s3_adapter()
         s3_key = s3.key(url)
         s3_object = s3.file(s3_key)
 
         if self.s3_object_is_up_to_date(s3_object, remote_timestamp):
-            # if so, mirror it locally
-            logging.info('downloading from s3 to {path}'.format(path=local_file_path))
+            logging.info(
+                'downloading from s3 to {path}'.format(path=local_file_path))
             s3.download(s3_object, local_file_path)
         else:
-            # so let's grab a local copy
-            logging.info('downloading from {url} to {path}'.format(url=url, path=local_file_path))
-            # nope, s3 object either not there or out of date
+            logging.info(
+                'downloading from {url} to {path}'.format(
+                    url=url,
+                    path=local_file_path))
             self.download_to_file(url, local_file_path)
-            # and upload *that* to s3 for later use
-            logging.info('uploading from {path} to s3 key {key}'.format(path=local_file_path, key=s3_key))
+
+            logging.info('uploading from {path} to s3 key {key}'.format(
+                path=local_file_path, key=s3_key))
             s3.upload(local_file_path, s3_key)
 
     def s3_adapter(self):
@@ -68,12 +70,11 @@ class DownloadManager(object):
         if local_copy:
             local_mod_time = os.path.getmtime(local_file_path)
             formatted_mod_time = self.format_time_for_orm(
-                                    local_mod_time)
-            result = self.up_to_date(formatted_mod_time,
-                                     remote_timestamp)
+                local_mod_time)
+            result = self.up_to_date(formatted_mod_time, remote_timestamp)
             return result
-        else:
-            return False
+
+        return False
 
     def _in_local_storage(self, local_path):
         return os.path.exists(local_path)
@@ -82,16 +83,18 @@ class DownloadManager(object):
         return copy_timestamp >= source_timestamp
 
     def s3_object_is_up_to_date(self, s3_object, remote_timestamp):
-        if s3_object is None:
-            return False
-        else:
+        if s3_object is not None:
             mod_time_on_s3 = self.format_time_for_orm(s3_object.last_modified)
             return self.up_to_date(mod_time_on_s3,
                                    remote_timestamp)
 
+        return False
+        
     def download_to_dir(self, url, dirpath, headers):
         filepath = self.filename(dirpath, url)
-        logging.info('downloading file from {url} to {path}'.format(url=url, path=filepath))
+        logging.info(
+            'downloading file from {url} to {path}'.format(
+                url=url, path=filepath))
         chunk_size = self.chunk_size()
         content_length = headers['content-length']
         return self.download_to_file(url, filepath, chunk_size, content_length)
@@ -106,8 +109,9 @@ class DownloadManager(object):
             count = 0
             for chunk in r.iter_content(chunk_size):
                 if content_length and count % 100 == 0:
-                    logging.debug('{0} bytes of {1}'.format(count*chunk_size,
-                                                            content_length))
+                    logging.debug('{0} bytes of {1}'.format(
+                        count*chunk_size,
+                        content_length))
                 count = count + 1
                 fd.write(chunk)
 

--- a/postcodeinfo/apps/postcode_api/downloaders/download_manager.py
+++ b/postcodeinfo/apps/postcode_api/downloaders/download_manager.py
@@ -6,27 +6,94 @@ from time import time, gmtime, strftime, strptime, mktime, localtime
 from datetime import datetime
 from dateutil import parser
 
+
 from postcode_api.models import Download
+from postcode_api.downloaders.s3_adapter import S3Adapter
 
 
 class DownloadManager(object):
 
-    def download_if_needed(self, url, dirpath, force=False):
+    # Reasons for this workflow:
+    # 1) Ordnance Survey only gives us AddressBase files
+    #    for a limited time after updates are released (21 days)
+    #    then it removes the file from their FTP server
+    #
+    # 2) Our release process re-creates an entirely new
+    #    docker container each time, so we can't just
+    #    cache the files locally
+    def retrieve(self, url, local_dir_path, force=False):
+        remote_timestamp = self.get_last_modified(url)
+        local_file_path = self.filename(local_dir_path, url)
+        
+        # if we have an up-to-date local copy, there's nothing to do
+        if not self.local_copy_up_to_date(local_file_path,
+                                        remote_timestamp):
+            self.get_from_s3(local_file_path, url, remote_timestamp)
+
+        return local_file_path
+
+    def get_from_s3(self, local_file_path, url, remote_timestamp):
+        # if we *don't* have an up-to-date local copy
+        # do we have one on s3?
+        s3 = self.s3_adapter()
+        s3_key = s3.key(url)
+        s3_object = s3.file(s3_key)
+
+        if self.s3_object_up_to_date(s3_object, remote_timestamp):
+            # if so, mirror it locally
+            s3.download(s3_object, local_file_path)
+        else:
+            # nope, s3 object either not there or out of date
+            # so let's grab a local copy
+            self.download_to_file(url, local_file_path)
+            # and upload *that* to s3 for later use
+            s3.upload(local_file_path, s3_key)
+
+    def s3_adapter(self):
+        S3Adapter()
+
+    def get_last_modified(self, url):
         headers = self.get_headers(url)
         if isinstance(headers, list):
             headers = headers[0]
 
-        download_record = self.existing_download_record(url, headers)
-        if self.download_is_needed(download_record) == True or force:
-            return self.do_download(url, dirpath, headers)
-        else:
-            print 'no download needed'
-            return None
+        return self.format_time_for_orm(headers['last-modified'])
 
-    def do_download(self, url, dirpath, headers):
-        local_path = self.download_to_dir(url, dirpath, headers)
-        download_record = self.record_download(url, dirpath, headers)
-        return download_record.local_filepath
+    def local_copy_up_to_date(self, local_file_path, remote_timestamp):
+        return (self._in_local_storage(local_file_path)
+                and self.up_to_date(os.path.getmtime(local_file_path),
+                                     remote_timestamp))
+
+    def _in_local_storage(self, local_path):
+        return os.path.exists(local_path)
+
+    def up_to_date(self, copy_timestamp, source_timestamp):
+        return (copy_timestamp >= source_timestamp)
+
+    def s3_object_up_to_date(self, s3_object, remote_timestamp):
+        return ((s3_object != None)
+                and self.up_to_date(s3_object.last_modified,
+                                     remote_timestamp))
+
+    # def s3_connection(self):
+    #     return S3Connection(region_name=settings.AWS['region_name'])
+
+    # def s3_bucket(self):
+    #     return self.s3_connection().get_bucket(settings.AWS['s3_bucket_name'])
+
+    # def s3_key(url):
+    #     return hashlib.sha512(url).hexdigest()
+
+    # def _file_on_s3(self, s3_key):
+    #     return self._s3_bucket().get_key(s3_key)
+
+    # def _download_from_s3(self, s3_object, local_file_path):
+    #     return s3_object.get_contents_to_filename(local_file_path)
+
+    # def upload_to_s3(self, local_file_path, s3_key):
+    #     k = Key(self.s3_bucket())
+    #     k.key = s3_key
+    #     return k.set_contents_from_string(local_file_path)
 
     def download_to_dir(self, url, dirpath, headers):
         filepath = self.filename(dirpath, url)
@@ -60,7 +127,7 @@ class DownloadManager(object):
         else:
             return r.headers
 
-    def _format_time_for_orm(self, given_time):
+    def format_time_for_orm(self, given_time):
         obj = None
         # is it a string?
         if isinstance(given_time, basestring):
@@ -72,48 +139,6 @@ class DownloadManager(object):
             obj = pytz.UTC.localize(obj)
 
         return obj
-
-    def record_download(self, url, dirpath, headers={}):
-        # create Download record storing the url, local path, last modified
-        # date, and etag
-        formatted_time = self._format_time_for_orm(headers['last-modified'])
-        dl = Download(url=url,
-                      etag=headers['etag'],
-                      last_modified=formatted_time)
-        dl.local_filepath = self.filename(dirpath, url)
-        dl.state = 'downloaded'
-        now = self._format_time_for_orm(localtime())
-        dl.last_state_change = now
-        dl.save()
-
-        return dl
-
-    def download_is_needed(self, download_record):
-        """ Basic naive strategy - if there's an existing record, we don't
-            need to re-download. (The existing record is found by the
-            combination of url, etag and last_modified, so if and only if
-            those three match, then we don't need to download).
-            This is sufficient for MVP 1 - future implementations can be as
-            complex as needed. """
-
-        if download_record:
-            return False
-        else:
-            # no existing record => download is needed
-            return True
-
-    def existing_download_record(self, url, headers):
-        last_modified = self._format_time_for_orm(headers['last-modified'])
-        dl = Download.objects.filter(url=url,
-                                     etag=headers['etag'],
-                                     last_modified=last_modified).first()
-        if dl:
-            print 'existing download record found: '
-            print '  state: %s since %s' % (dl.state,  dl.last_state_change)
-            print '  last_modified: %s' % dl.last_modified
-            print '  etag: %s' % dl.etag
-            print '  local_filepath: %s' % dl.local_filepath
-        return dl
 
     def filename(self, dirname, url):
         return dirname + url.split('/')[-1]

--- a/postcodeinfo/apps/postcode_api/downloaders/download_manager.py
+++ b/postcodeinfo/apps/postcode_api/downloaders/download_manager.py
@@ -85,11 +85,10 @@ class DownloadManager(object):
     def s3_object_is_up_to_date(self, s3_object, remote_timestamp):
         if s3_object is not None:
             mod_time_on_s3 = self.format_time_for_orm(s3_object.last_modified)
-            return self.up_to_date(mod_time_on_s3,
-                                   remote_timestamp)
+            return self.up_to_date(mod_time_on_s3, remote_timestamp)
 
         return False
-        
+
     def download_to_dir(self, url, dirpath, headers):
         filepath = self.filename(dirpath, url)
         logging.info(

--- a/postcodeinfo/apps/postcode_api/downloaders/ftp_download_manager.py
+++ b/postcodeinfo/apps/postcode_api/downloaders/ftp_download_manager.py
@@ -34,7 +34,7 @@ class FTPDownloadManager(DownloadManager):
         downloads = []
         print '%i files matching %s' % (len(files), pattern)
         for file in files:
-            dl = self.download_if_needed(file, dirpath, force)
+            dl = self.retrieve(file, dirpath, force)
             if dl:
                 downloads.append(dl)
 

--- a/postcodeinfo/apps/postcode_api/downloaders/local_authorities_downloader.py
+++ b/postcodeinfo/apps/postcode_api/downloaders/local_authorities_downloader.py
@@ -10,8 +10,8 @@ class LocalAuthoritiesDownloader(object):
         dl_mgr = DownloadManager()
 
         return dl_mgr.retrieve(most_recent_file_url,
-                                         target_dir,
-                                         force)
+                               target_dir,
+                               force)
 
     def _target_href(self):
         return 'http://opendatacommunities.org/data/dev-local-authorities/dump'

--- a/postcodeinfo/apps/postcode_api/downloaders/local_authorities_downloader.py
+++ b/postcodeinfo/apps/postcode_api/downloaders/local_authorities_downloader.py
@@ -9,7 +9,7 @@ class LocalAuthoritiesDownloader(object):
 
         dl_mgr = DownloadManager()
 
-        return dl_mgr.download_if_needed(most_recent_file_url,
+        return dl_mgr.retrieve(most_recent_file_url,
                                          target_dir,
                                          force)
 

--- a/postcodeinfo/apps/postcode_api/downloaders/postcode_gss_code_downloader.py
+++ b/postcodeinfo/apps/postcode_api/downloaders/postcode_gss_code_downloader.py
@@ -11,15 +11,22 @@ class PostcodeGssCodeDownloader(object):
         most_recent_file_url = self._target_href()
 
         dl_mgr = DownloadManager()
-        return dl_mgr.download_if_needed(most_recent_file_url,
+        #import pdb; pdb.set_trace()
+
+        return dl_mgr.retrieve(most_recent_file_url,
                                          target_dir,
                                          force)
 
     def _target_href(self):
-        index_json = requests.get(self._index_json_url()).text
+        # import pdb; pdb.set_trace()
+
+        index_json = self._get_index_json()
         index = json.loads(index_json)
 
         return self._get_most_recent_file_url(index)
+
+    def _get_index_json(self):
+        return requests.get(self.index_json_url()).text
 
     def _get_most_recent_file_url(self, parsed_index):
         nspl_elements = filter(
@@ -28,7 +35,7 @@ class PostcodeGssCodeDownloader(object):
             nspl_elements, key=lambda e: e['updated'], reverse=True)[0]
         return self._file_url(most_recent['links'])
 
-    def _index_json_url(self):
+    def index_json_url(self):
         return 'https://geoportal.statistics.gov.uk/geoportal'\
             '/rest/find/document?searchText=NSPL&f=pjson'
 

--- a/postcodeinfo/apps/postcode_api/downloaders/postcode_gss_code_downloader.py
+++ b/postcodeinfo/apps/postcode_api/downloaders/postcode_gss_code_downloader.py
@@ -11,15 +11,12 @@ class PostcodeGssCodeDownloader(object):
         most_recent_file_url = self._target_href()
 
         dl_mgr = DownloadManager()
-        #import pdb; pdb.set_trace()
 
         return dl_mgr.retrieve(most_recent_file_url,
-                                         target_dir,
-                                         force)
+            target_dir,
+            force)
 
     def _target_href(self):
-        # import pdb; pdb.set_trace()
-
         index_json = self._get_index_json()
         index = json.loads(index_json)
 

--- a/postcodeinfo/apps/postcode_api/downloaders/s3_adapter.py
+++ b/postcodeinfo/apps/postcode_api/downloaders/s3_adapter.py
@@ -1,0 +1,32 @@
+import boto
+
+from django.conf import settings
+
+from boto.s3.connection import S3Connection
+from boto.s3.key import Key
+
+class S3Adapter(object):
+
+    def __init__(self, connection=None, bucket=None):
+        self.connection = connection or self.connect()
+        self.bucket = bucket or self.bucket()
+
+    def connect(self, region_name=settings.AWS['region_name']): 
+        return boto.s3.connect_to_region(region_name) 
+ 
+    def bucket(self, bucket_name=settings.AWS['s3_bucket_name']): 
+        return self.connection().get_bucket(bucket_name) 
+ 
+    def key(url): 
+        return hashlib.sha512(url).hexdigest() 
+ 
+    def file(self, key): 
+        return self.bucket().get_key(key) 
+ 
+    def download(self, s3_object, local_file_path): 
+        return s3_object.get_contents_to_filename(local_file_path) 
+ 
+    def upload(self, local_file_path, s3_key): 
+        k = Key(self.bucket()) 
+        k.key = s3_key 
+        return k.set_contents_from_string(local_file_path) 

--- a/postcodeinfo/apps/postcode_api/downloaders/s3_adapter.py
+++ b/postcodeinfo/apps/postcode_api/downloaders/s3_adapter.py
@@ -1,5 +1,4 @@
 import boto
-import hashlib
 
 from django.conf import settings
 
@@ -9,13 +8,18 @@ from boto.s3.key import Key
 class S3Adapter(object):
 
     def __init__(self, connection=None, bucket=None):
-        self.connection = connection or self.connect()
-        self.bucket = bucket or self.bucket()
+        self.connection = connection
+        if connection is None:
+            self.connection = self.connect()
+
+        self.bucket = bucket
+        if bucket is None:
+            self.bucket = self.get_bucket()
 
     def connect(self, region_name=settings.AWS['region_name']): 
         return boto.s3.connect_to_region(region_name) 
  
-    def bucket(self, bucket_name=settings.AWS['s3_bucket_name']): 
+    def get_bucket(self, bucket_name=settings.AWS['s3_bucket_name']): 
         return self.connection.get_bucket(bucket_name) 
  
     def key(self, url): 

--- a/postcodeinfo/apps/postcode_api/downloaders/s3_adapter.py
+++ b/postcodeinfo/apps/postcode_api/downloaders/s3_adapter.py
@@ -25,7 +25,8 @@ class S3Adapter(object):
         return self.bucket.get_key(key) 
  
     def download(self, s3_object, local_file_path): 
-        return s3_object.get_contents_to_filename(local_file_path) 
+        s3_object.get_contents_to_filename(local_file_path) 
+        return local_file_path
  
     def upload(self, local_file_path, s3_key): 
         k = Key(self.bucket) 

--- a/postcodeinfo/apps/postcode_api/downloaders/s3_adapter.py
+++ b/postcodeinfo/apps/postcode_api/downloaders/s3_adapter.py
@@ -1,4 +1,5 @@
 import boto
+import hashlib
 
 from django.conf import settings
 
@@ -15,18 +16,18 @@ class S3Adapter(object):
         return boto.s3.connect_to_region(region_name) 
  
     def bucket(self, bucket_name=settings.AWS['s3_bucket_name']): 
-        return self.connection().get_bucket(bucket_name) 
+        return self.connection.get_bucket(bucket_name) 
  
-    def key(url): 
-        return hashlib.sha512(url).hexdigest() 
+    def key(self, url): 
+        return url.split('/')[-1]
  
     def file(self, key): 
-        return self.bucket().get_key(key) 
+        return self.bucket.get_key(key) 
  
     def download(self, s3_object, local_file_path): 
         return s3_object.get_contents_to_filename(local_file_path) 
  
     def upload(self, local_file_path, s3_key): 
-        k = Key(self.bucket()) 
+        k = Key(self.bucket) 
         k.key = s3_key 
-        return k.set_contents_from_string(local_file_path) 
+        return k.set_contents_from_filename(local_file_path) 

--- a/postcodeinfo/apps/postcode_api/management/commands/download_and_import_addressbase_basic.py
+++ b/postcodeinfo/apps/postcode_api/management/commands/download_and_import_addressbase_basic.py
@@ -66,10 +66,6 @@ class Command(BaseCommand):
         for path in files:
             print 'importing ' + path
             self._import(path)
-            self._cleanup(path)
-
-        if os.path.exists(filepath):
-            self._cleanup(filepath)
 
         return True
 
@@ -77,6 +73,3 @@ class Command(BaseCommand):
         importer = AddressBaseBasicImporter()
         importer.import_csv(downloaded_file)
 
-    def _cleanup(self, downloaded_file):
-        print 'removing local file ' + downloaded_file
-        os.remove(downloaded_file)

--- a/postcodeinfo/apps/postcode_api/management/commands/download_and_import_local_authorities.py
+++ b/postcodeinfo/apps/postcode_api/management/commands/download_and_import_local_authorities.py
@@ -57,9 +57,6 @@ class Command(BaseCommand):
         for path in files:
             print 'importing ' + path
             result = self._import(path)
-            self._cleanup(path)
-
-        self._cleanup(filepath)
 
     def _import(self, downloaded_file):
         importer = LocalAuthoritiesImporter()

--- a/postcodeinfo/apps/postcode_api/management/commands/download_and_import_postcode_gss_codes.py
+++ b/postcodeinfo/apps/postcode_api/management/commands/download_and_import_postcode_gss_codes.py
@@ -58,10 +58,6 @@ class Command(BaseCommand):
         for path in files:
             print 'importing ' + path
             self._import(path)
-            self._cleanup(path)
-
-        if os.path.exists(filepath):
-            self._cleanup(filepath)
 
         return True
 
@@ -69,6 +65,3 @@ class Command(BaseCommand):
         importer = PostcodeGssCodeImporter()
         importer.import_postcode_gss_codes(downloaded_file)
 
-    def _cleanup(self, downloaded_file):
-        print 'removing local file ' + downloaded_file
-        os.remove(downloaded_file)

--- a/postcodeinfo/apps/postcode_api/tests/downloaders/test_addressbase_basic_downloader.py
+++ b/postcodeinfo/apps/postcode_api/tests/downloaders/test_addressbase_basic_downloader.py
@@ -42,3 +42,40 @@ class AddressBaseBasicDownloaderTestCase(TestCase):
 
         self._downloader(mock).download('/some/other/dir', False)
         mock.download_all_if_needed.assertCalledWith('/some/other/dir', False)
+
+    @patch('postcode_api.downloaders.addressbase_basic_downloader.AddressBaseBasicDownloader.local_files', return_value=['local_files'])
+    @patch('postcode_api.downloaders.ftp_download_manager.FTPDownloadManager')
+    def test_that_when_the_ftp_call_raises_an_exception_and_local_files_exist_it_returns_the_local_files(self, mock, mock_local_files):
+        dl = self._downloader(mock)
+        dl.ftp_client().cwd.side_effect = ftplib.error_perm
+        self.assertEqual( ['local_files'], dl.download('/some/other/dir', False) )
+
+
+    @patch('postcode_api.downloaders.addressbase_basic_downloader.AddressBaseBasicDownloader.files_from_s3', return_value=['files from s3'])
+    @patch('postcode_api.downloaders.addressbase_basic_downloader.AddressBaseBasicDownloader.local_files', return_value=[])
+    @patch('postcode_api.downloaders.ftp_download_manager.FTPDownloadManager')
+    def test_that_when_the_ftp_call_raises_an_exception_and_local_files_dont_exist_it_returns_the_files_from_s3(self, mock, mock_local_files, mock_s3_files):
+        dl = self._downloader(mock)
+        dl.ftp_client().cwd.side_effect = ftplib.error_perm
+        #dl.ftp_client.cwd.side_effect=ftplib.error_perm
+        self.assertEqual( ['files from s3'], dl.download('/some/other/dir', False) )
+
+    # describe: local_files
+    @patch('glob.glob')
+    def test_that_it_globs_for_zipped_csv_files_in_local_dir(self, mock):
+        self._downloader(mock).local_files('/local/dir/')
+        mock.assertCalledWith('/local/dir/*csv.zip')
+
+    @patch('glob.glob', return_value=['f1','f2'])
+    def test_that_it_globs_for_zipped_csv_files_in_local_dir(self, mock):
+        result = self._downloader(mock).local_files('/local/dir/')
+        self.assertEqual(['f1','f2'], result)
+
+    # describe: files_from_s3
+    @patch('postcode_api.downloaders.s3_adapter.S3Adapter')
+    def test_that_it_lists_addressbase_files_in_the_s3_adapters_bucket(self, mock):
+        dl = self._downloader(mock)
+        result = dl.files_from_s3
+        mock.bucket.list.assertCalledWith('AddressBase')
+
+

--- a/postcodeinfo/apps/postcode_api/tests/downloaders/test_download_manager.py
+++ b/postcodeinfo/apps/postcode_api/tests/downloaders/test_download_manager.py
@@ -140,40 +140,46 @@ class DownloadManagerTestCase(TestCase):
     # describe: local_copy_up_to_date
     @patch('postcode_api.downloaders.download_manager.DownloadManager._in_local_storage', return_value=True)
     @patch('postcode_api.downloaders.download_manager.DownloadManager.up_to_date', return_value=True)
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.format_time_for_orm', return_value='12345')
     @patch('os.path.getmtime', return_value='12345')
-    def test_that_when_the_file_is_in_local_storage_and_up_to_date_it_returns_true(self, mock_file_timestamp, mock_up_to_date, mock_in_local_storage):
+    def test_that_when_the_file_is_in_local_storage_and_up_to_date_it_returns_true(self, mock_file_timestamp, mock_format_time_for_orm, mock_up_to_date, mock_in_local_storage):
         self.assertEqual( True, subject().local_copy_up_to_date('local/path', 'remote timestamp') )
 
     @patch('postcode_api.downloaders.download_manager.DownloadManager._in_local_storage', return_value=True)
     @patch('postcode_api.downloaders.download_manager.DownloadManager.up_to_date', return_value=False)
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.format_time_for_orm', return_value='12345')
     @patch('os.path.getmtime', return_value='12345')
-    def test_that_when_the_file_is_in_local_storage_and_not_up_to_date_it_returns_false(self, mock_file_timestamp, mock_up_to_date, mock_in_local_storage):
+    def test_that_when_the_file_is_in_local_storage_and_not_up_to_date_it_returns_false(self, mock_file_timestamp, mock_format_time_for_orm, mock_up_to_date, mock_in_local_storage):
         self.assertEqual( False, subject().local_copy_up_to_date('local/path', 'remote timestamp') )
 
     @patch('postcode_api.downloaders.download_manager.DownloadManager._in_local_storage', return_value=False)
     @patch('postcode_api.downloaders.download_manager.DownloadManager.up_to_date', return_value=True)
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.format_time_for_orm', return_value='12345')
     @patch('os.path.getmtime', return_value='12345')
-    def test_that_when_the_file_is_not_in_local_storage_it_returns_false(self, mock_file_timestamp, mock_up_to_date, mock_in_local_storage):
+    def test_that_when_the_file_is_not_in_local_storage_it_returns_false(self, mock_file_timestamp, mock_format_time_for_orm, mock_up_to_date, mock_in_local_storage):
         self.assertEqual( False, subject().local_copy_up_to_date('local/path', 'remote timestamp') )
 
     # describe: s3_object_up_to_date
     @patch('postcode_api.downloaders.download_manager.DownloadManager.up_to_date', return_value=True)
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.format_time_for_orm', return_value='12345')
     @patch('os.path.getmtime', return_value='12345')
-    def test_that_when_the_s3_object_exists_and_is_up_to_date_it_returns_true(self, mock_file_timestamp, mock_up_to_date):
+    def test_that_when_the_s3_object_exists_and_is_up_to_date_it_returns_true(self, mock_file_timestamp, mock_format_time_for_orm, mock_up_to_date):
         s3_object = MagicMock(last_modified='12345')
         self.assertEqual( True, subject().s3_object_up_to_date(s3_object, 'remote timestamp') )
     
     # describe: s3_object_up_to_date
     @patch('postcode_api.downloaders.download_manager.DownloadManager.up_to_date', return_value=False)
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.format_time_for_orm', return_value='12345')
     @patch('os.path.getmtime', return_value='12345')
-    def test_that_when_the_s3_object_exists_and_is_not_up_to_date_it_returns_false(self, mock_file_timestamp, mock_up_to_date):
+    def test_that_when_the_s3_object_exists_and_is_not_up_to_date_it_returns_false(self, mock_file_timestamp, mock_format_time_for_orm, mock_up_to_date):
         s3_object = MagicMock(last_modified='12345')
         self.assertEqual( False, subject().s3_object_up_to_date(s3_object, 'remote timestamp') )
 
     # describe: s3_object_up_to_date
     @patch('postcode_api.downloaders.download_manager.DownloadManager.up_to_date', return_value=False)
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.format_time_for_orm', return_value='12345')
     @patch('os.path.getmtime', return_value='12345')
-    def test_that_when_the_s3_object_does_not_exist_it_returns_true(self, mock_file_timestamp, mock_up_to_date):
+    def test_that_when_the_s3_object_does_not_exist_it_returns_true(self, mock_file_timestamp, mock_format_time_for_orm, mock_up_to_date):
         self.assertEqual( False, subject().s3_object_up_to_date(None, 'remote timestamp') )
     
     # describe test_up_to_date

--- a/postcodeinfo/apps/postcode_api/tests/downloaders/test_download_manager.py
+++ b/postcodeinfo/apps/postcode_api/tests/downloaders/test_download_manager.py
@@ -7,9 +7,11 @@ import tempfile
 from django.test import TestCase
 from mock import patch, MagicMock
 from dateutil import parser
+from datetime import datetime, timedelta
 
 from postcode_api.models import Download
 from postcode_api.downloaders.download_manager import DownloadManager
+from postcode_api.downloaders.s3_adapter import S3Adapter
 
 
 def subject():
@@ -44,49 +46,6 @@ class DownloadManagerTestCase(TestCase):
     def test_that_given_a_url_and_a_dir_it_returns_the_last_element_appended_to_the_dir(self):
         self.assertEqual(subject().filename(
             '/my/dir/path/', 'http://some.com/some/file.json'), '/my/dir/path/file.json')
-
-    # describe: existing_download_record
-    def test_that_a_record_that_matches_url_etag_and_last_modified_is_returned(self):
-        headers = {'etag': '12345', 'last-modified': '2015-05-09 09:12:35'}
-        self.assertEqual(self._existing_record(headers),
-                         subject().existing_download_record('http://my/url.html',
-                                                            headers))
-
-    def test_that_a_record_that_matches_url_etag_but_not_last_modified_is_not_returned(self):
-        headers_existing = {
-            'etag': '12345', 'last-modified': '2015-05-09 09:12:35'}
-        headers_looked_for = {
-            'etag': headers_existing['etag'], 'last-modified': '2015-01-01 23:23:23'}
-        existing_record = self._existing_record(headers_existing)
-        self.assertEqual(None, subject().existing_download_record(
-            'http://my/url.html', headers_looked_for))
-
-    def test_that_a_record_that_matches_url_and_last_modified_but_not_etag_is_not_returned(self):
-        headers_existing = {
-            'etag': '12345', 'last-modified': '2015-05-09 09:12:35'}
-        headers_looked_for = {
-            'etag': 'foobar', 'last-modified': headers_existing['last-modified']}
-        existing_record = self._existing_record(headers_existing)
-        self.assertEqual(None, subject().existing_download_record(
-            'http://my/url.html', headers_looked_for))
-
-    # describe: download_is_needed
-    def test_that_when_given_a_thing_it_returns_false(self):
-        self.assertEqual(False, subject().download_is_needed('something'))
-
-    def test_that_when_given_nothing_it_returns_true(self):
-        self.assertEqual(True, subject().download_is_needed(None))
-
-    # describe: record_download
-    def test_that_it_creates_a_download_record_with_the_right_attributes(self):
-        headers = {'etag': '12345', 'last-modified': '2015-05-09 09:12:35'}
-        dl = subject().record_download(
-            'http://my/url.html', '/my/dir/path/', headers)
-        self.assertEqual('http://my/url.html', dl.url)
-        self.assertEqual('12345', dl.etag)
-        self.assertEqual('/my/dir/path/url.html', dl.local_filepath)
-        self.assertEqual('downloaded', dl.state)
-        self.assertEqual('http://my/url.html', dl.url)
 
     # describe: get_headers
     @patch('requests.head')
@@ -125,35 +84,128 @@ class DownloadManagerTestCase(TestCase):
         mock.assertCalledWith(
             'http://some.url/test.file', '/my/dir/path/test.file', 4192, 1234)
 
-    # describe: download_if_needed
-    @patch('postcode_api.downloaders.download_manager.DownloadManager.get_headers')
-    @patch('postcode_api.downloaders.download_manager.DownloadManager.download_is_needed')
-    @patch('postcode_api.downloaders.download_manager.DownloadManager.do_download')
-    @patch('postcode_api.downloaders.download_manager.DownloadManager.existing_download_record')
-    def test_that_when_download_is_needed_then_it_downloads_the_given_url_to_the_given_dir(self, mock_hdrs, mock_dl_needed, mock_do_download, mock_existing_download_record):
-        mock_dl_needed.return_value = True
-        rtn_val = subject().download_if_needed(
-            'http://some.url/test.file', '/my/dir/path/')
-        mock_do_download.assertCalledWith(
-            'http://some.url/test.file', '/my/dir/path/')
+    # describe: retrieve
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.get_last_modified', return_value='12345')
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.get_from_s3')
+    def test_that_when_the_local_copy_is_not_up_to_date_then_it_gets_from_s3(self, mock_get_from_s3, mock_last_modified):
+        s = subject()
+        s._local_copy_up_to_date = MagicMock(False)
+        s.retrieve('test.url', '/local/path')
+        mock_get_from_s3.assertCalledWith('/local/path', '12345')
 
-    @patch('postcode_api.downloaders.download_manager.DownloadManager.get_headers')
-    @patch('postcode_api.downloaders.download_manager.DownloadManager.download_is_needed')
-    @patch('postcode_api.downloaders.download_manager.DownloadManager.do_download')
-    @patch('postcode_api.downloaders.download_manager.DownloadManager.existing_download_record')
-    def test_that_when_download_is_not_needed_then_it_does_not_download(self, mock_hdrs, mock_dl_needed, mock_do_download, mock_existing_download_record):
-        mock_dl_needed.return_value = False
-        rtn_val = subject().download_if_needed(
-            'http://some.url/test.file', '/my/dir/path/')
-        self.assertEqual(rtn_val, None)
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.get_last_modified', return_value='12345')
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.get_from_s3')
+    def test_that_when_the_local_copy_is_up_to_date_then_it_does_not_get_from_s3(self, mock_get_from_s3, mock_last_modified):
+        s = subject()
+        s.local_copy_up_to_date = MagicMock(True)
+        s.retrieve('test.url', '/local/path')
+        assert not mock_get_from_s3.called
 
-    @patch('postcode_api.downloaders.download_manager.DownloadManager.get_headers')
-    @patch('postcode_api.downloaders.download_manager.DownloadManager.download_is_needed')
-    @patch('postcode_api.downloaders.download_manager.DownloadManager.do_download')
-    @patch('postcode_api.downloaders.download_manager.DownloadManager.existing_download_record')
-    def test_that_when_download_is_not_needed_but_force_is_passed_then_it_does_download(self, mock_hdrs, mock_dl_needed, mock_do_download, mock_existing_download_record):
-        mock_dl_needed.return_value = False
-        rtn_val = subject().download_if_needed(
-            'http://some.url/test.file', '/my/dir/path/', True)
-        mock_do_download.assertCalledWith(
-            'http://some.url/test.file', '/my/dir/path/')
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.filename', return_value='/my/local/filename')
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.get_last_modified', return_value='12345')
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.get_from_s3')
+    def test_that_it_returns_the_local_file_path(self, mock_get_from_s3, mock_last_modified, mock_filename):
+        s = subject()
+        s.local_copy_up_to_date = MagicMock(True)
+        self.assertEqual( '/my/local/filename', s.retrieve('test.url', '/local/path') )
+        
+
+    # describe: get_from_s3
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.s3_adapter')
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.get_last_modified', return_value='12345')
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.s3_object_up_to_date', return_value=True)
+    def test_that_when_the_s3_object_is_up_to_date_it_downloads_the_file_from_s3(self, mock_s3_object_up_to_date, mock_get_last_modified, mock_s3_adapter):
+        s = subject()
+        s.get_from_s3('test.url', '/local/path', '12345')
+        self.assertEqual(True, mock_s3_adapter().download.called )
+
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.s3_adapter')
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.s3_object_up_to_date', return_value=False)
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.download_to_file', return_value=True)
+    def test_that_when_the_s3_object_is_not_up_to_date_it_downloads_the_file_locally(self, mock_download_to_file, mock_s3_object_up_to_date, mock_s3_adapter):
+        s = subject()
+        s.get_from_s3('test.url', '/local/path', '12345')
+        mock_download_to_file.assertCalledWith('test.url', '/local/path')
+
+    
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.s3_adapter')
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.get_last_modified', return_value='12345')
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.s3_object_up_to_date', return_value=False)
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.download_to_file', return_value=True)
+    def test_that_when_the_s3_object_is_not_up_to_date_it_uploads_the_local_file_to_s3(self, mock_download_to_file, mock_s3_object_up_to_date, mock_get_last_modified, mock_s3_adapter):
+        s = subject()
+        s.get_from_s3('test.url', '/local/path', '12345')
+        mock_s3_adapter.upload.assertCalledWith('test.url', '/local/path')
+
+    # describe: local_copy_up_to_date
+    @patch('postcode_api.downloaders.download_manager.DownloadManager._in_local_storage', return_value=True)
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.up_to_date', return_value=True)
+    @patch('os.path.getmtime', return_value='12345')
+    def test_that_when_the_file_is_in_local_storage_and_up_to_date_it_returns_true(self, mock_file_timestamp, mock_up_to_date, mock_in_local_storage):
+        self.assertEqual( True, subject().local_copy_up_to_date('local/path', 'remote timestamp') )
+
+    @patch('postcode_api.downloaders.download_manager.DownloadManager._in_local_storage', return_value=True)
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.up_to_date', return_value=False)
+    @patch('os.path.getmtime', return_value='12345')
+    def test_that_when_the_file_is_in_local_storage_and_not_up_to_date_it_returns_false(self, mock_file_timestamp, mock_up_to_date, mock_in_local_storage):
+        self.assertEqual( False, subject().local_copy_up_to_date('local/path', 'remote timestamp') )
+
+    @patch('postcode_api.downloaders.download_manager.DownloadManager._in_local_storage', return_value=False)
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.up_to_date', return_value=True)
+    @patch('os.path.getmtime', return_value='12345')
+    def test_that_when_the_file_is_not_in_local_storage_it_returns_false(self, mock_file_timestamp, mock_up_to_date, mock_in_local_storage):
+        self.assertEqual( False, subject().local_copy_up_to_date('local/path', 'remote timestamp') )
+
+    # describe: s3_object_up_to_date
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.up_to_date', return_value=True)
+    @patch('os.path.getmtime', return_value='12345')
+    def test_that_when_the_s3_object_exists_and_is_up_to_date_it_returns_true(self, mock_file_timestamp, mock_up_to_date):
+        s3_object = MagicMock(last_modified='12345')
+        self.assertEqual( True, subject().s3_object_up_to_date(s3_object, 'remote timestamp') )
+    
+    # describe: s3_object_up_to_date
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.up_to_date', return_value=False)
+    @patch('os.path.getmtime', return_value='12345')
+    def test_that_when_the_s3_object_exists_and_is_not_up_to_date_it_returns_false(self, mock_file_timestamp, mock_up_to_date):
+        s3_object = MagicMock(last_modified='12345')
+        self.assertEqual( False, subject().s3_object_up_to_date(s3_object, 'remote timestamp') )
+
+    # describe: s3_object_up_to_date
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.up_to_date', return_value=False)
+    @patch('os.path.getmtime', return_value='12345')
+    def test_that_when_the_s3_object_does_not_exist_it_returns_true(self, mock_file_timestamp, mock_up_to_date):
+        self.assertEqual( False, subject().s3_object_up_to_date(None, 'remote timestamp') )
+    
+    # describe test_up_to_date
+    def test_that_when_copy_timestamp_is_greater_than_source_timestamp_it_returns_true(self):
+        self.assertEqual( True, subject().up_to_date( datetime.now(), datetime.now() - timedelta(hours=1) ) )
+
+    def test_that_when_copy_timestamp_is_equal_to_source_timestamp_it_returns_true(self):
+        now = datetime.now()
+        self.assertEqual( True, subject().up_to_date( now, now ) )
+
+    def test_that_when_copy_timestamp_is_less_than_source_timestamp_it_returns_false(self):
+        self.assertEqual( False, subject().up_to_date( datetime.now() - timedelta(hours=1), datetime.now() ) )
+
+    # describe: get_last_modified
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.get_headers', return_value={'last-modified':'some time ago'})
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.format_time_for_orm', return_value='formatted time')
+    def test_that_it_gets_headers_with_the_given_url(self, mock_format_time_for_orm, mock_get_headers):
+        result = subject().get_last_modified('a.url')
+        mock_get_headers.assertCalledWith('a.url')
+        mock_format_time_for_orm.assertCalledWith('some time ago')
+        self.assertEqual('formatted time', result)
+
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.get_headers', return_value=[{'last-modified':'some time ago'},{'last-modified':'some other time'}])
+    @patch('postcode_api.downloaders.download_manager.DownloadManager.format_time_for_orm', return_value='formatted time')
+    def test_that_when_headers_is_a_list_it_uses_the_first_element(self, mock_format_time_for_orm, mock_get_headers):
+        result = subject().get_last_modified('a.url')
+        mock_format_time_for_orm.assertCalledWith('some time ago')
+        
+    # describe format_time_for_orm
+    def test_that_given_a_string_it_returns_a_datetime(self):
+        result = subject().format_time_for_orm('17-12-2015 00:01:02')
+        self.assertEqual( True, isinstance(result, datetime) )
+
+
+

--- a/postcodeinfo/apps/postcode_api/tests/downloaders/test_download_manager.py
+++ b/postcodeinfo/apps/postcode_api/tests/downloaders/test_download_manager.py
@@ -214,4 +214,6 @@ class DownloadManagerTestCase(TestCase):
         self.assertEqual( True, isinstance(result, datetime) )
 
 
-
+    # TODO: test case when file list doesn't exist remotely - how can we handle that?
+    # It should try to retrieve ... a list of files from s3 with a given name pattern?
+    # How does it know the name pattern to use? Handle this in the downloaders, probably

--- a/postcodeinfo/apps/postcode_api/tests/downloaders/test_ftp_download_manager.py
+++ b/postcodeinfo/apps/postcode_api/tests/downloaders/test_ftp_download_manager.py
@@ -44,9 +44,9 @@ class FTPDownloadManagerTestCase(TestCase):
             ['/my/url/1', '/my/url/2'], subject().list_files('my pattern'))
 
     # describe: download_all_if_needed
-    @patch('postcode_api.downloaders.ftp_download_manager.FTPDownloadManager.download_if_needed')
+    @patch('postcode_api.downloaders.ftp_download_manager.FTPDownloadManager.retrieve')
     @patch('postcode_api.downloaders.ftp_download_manager.FTPDownloadManager.list_files')
-    def test_that_it_calls_download_if_needed_for_each_listed_file(self, mock_list_files, mock_dl_if_needed):
+    def test_that_it_calls_retrieve_for_each_listed_file(self, mock_list_files, mock_dl_if_needed):
         mock_list_files.return_value = ['file/1', 'file/2']
         mock_dl_if_needed.side_effect = ['/local/file/1', '/local/file/2']
         calls = [call('file/1', '/dir/path', False),
@@ -54,7 +54,7 @@ class FTPDownloadManagerTestCase(TestCase):
         subject().download_all_if_needed('my pattern', '/dir/path')
         mock_dl_if_needed.assert_has_calls(calls)
 
-    @patch('postcode_api.downloaders.ftp_download_manager.FTPDownloadManager.download_if_needed')
+    @patch('postcode_api.downloaders.ftp_download_manager.FTPDownloadManager.retrieve')
     @patch('postcode_api.downloaders.ftp_download_manager.FTPDownloadManager.list_files')
     def test_that_it_returns_the_local_filepath_of_all_downloads_performed(self, mock_list_files, mock_dl_if_needed):
         mock_list_files.return_value = ['file/1', 'file/2']

--- a/postcodeinfo/apps/postcode_api/tests/downloaders/test_local_authorities_downloader.py
+++ b/postcodeinfo/apps/postcode_api/tests/downloaders/test_local_authorities_downloader.py
@@ -10,20 +10,20 @@ class LocalAuthoritiesDownloaderTestCase(TestCase):
     def _downloader(self):
         return LocalAuthoritiesDownloader()
 
-    @patch.object(DownloadManager, 'download_if_needed')
-    def test_that_download_if_needed_is_called(self, mock):
+    @patch.object(DownloadManager, 'retrieve')
+    def test_that_retrieve_is_called(self, mock):
         self._downloader().download()
         self.assertTrue(mock.called)
         mock.assertCalledWith(
             'http://opendatacommunities.org/data/dev-local-authorities/dump', '/tmp/', False)
 
-    @patch.object(DownloadManager, 'download_if_needed')
+    @patch.object(DownloadManager, 'retrieve')
     def test_that_a_given_target_dir_is_passed_to_the_downloader(self, mock):
         self._downloader().download('/my/target/dir/')
         mock.assertCalledWith(
             'http://opendatacommunities.org/data/dev-local-authorities/dump', '/my/target/dir/', False)
 
-    @patch.object(DownloadManager, 'download_if_needed')
+    @patch.object(DownloadManager, 'retrieve')
     def test_that_a_given_force_value_is_passed_to_the_downloader(self, mock):
         self._downloader().download('/tmp/', True)
         mock.assertCalledWith(

--- a/postcodeinfo/apps/postcode_api/tests/downloaders/test_postcode_gss_code_downloader.py
+++ b/postcodeinfo/apps/postcode_api/tests/downloaders/test_postcode_gss_code_downloader.py
@@ -6,8 +6,10 @@ from mock import MagicMock
 import responses
 import requests
 
-from postcode_api.downloaders.postcode_gss_code_downloader import PostcodeGssCodeDownloader
-from postcode_api.downloaders.download_manager import DownloadManager
+from postcode_api.downloaders.postcode_gss_code_downloader\
+    import PostcodeGssCodeDownloader
+from postcode_api.downloaders.download_manager\
+    import DownloadManager
 
 
 class PostcodeGssCodeDownloaderTestCase(TestCase):
@@ -15,36 +17,40 @@ class PostcodeGssCodeDownloaderTestCase(TestCase):
     def _downloader(self):
         return PostcodeGssCodeDownloader()
 
+    def _downloader_with_mocked_index_json(self):
+        dl = self._downloader()
+        dl._get_index_json = MagicMock(return_value=self._mock_geoportal_response())
+        return dl
+
     def _sample_data_file(self, filename):
-        return os.path.join(os.path.dirname(__file__), '../', 'sample_data/', filename)
+        return os.path.join(os.path.dirname(__file__),
+                            '../',
+                            'sample_data/',
+                            filename)
 
     def _mock_geoportal_response(self):
-        return open(self._sample_data_file('os_geoportal_response.json'), 'rb').read()
+        return open(self._sample_data_file('os_geoportal_response.json'),
+                    'rb').read()
 
-    @patch.object(DownloadManager, 'download_if_needed')
-    def test_that_download_if_needed_is_called(self, mock):
-        self._downloader()._target_href = MagicMock('http://mock/url')
-        self._downloader().download()
+    @patch.object(DownloadManager, 'retrieve')
+    def test_that_retrieve_is_called(self, mock):
+        self._downloader_with_mocked_index_json().download()
         self.assertTrue(mock.called)
         mock.assertCalledWith('http://mock/url', '/tmp/', False)
 
-    @patch.object(DownloadManager, 'download_if_needed')
+    @patch.object(DownloadManager, 'retrieve')
     def test_that_a_given_target_dir_is_passed_to_the_downloader(self, mock):
-        self._downloader().download('/my/target/dir/')
+        self._downloader_with_mocked_index_json().download('/my/target/dir/')
         mock.assertCalledWith('http://mock/url', '/my/target/dir/', False)
 
-    @patch.object(DownloadManager, 'download_if_needed')
+    @patch.object(DownloadManager, 'retrieve')
     def test_that_a_given_force_value_is_passed_to_the_downloader(self, mock):
-        self._downloader().download('/tmp/', True)
+        self._downloader_with_mocked_index_json().download('/tmp/', True)
         mock.assertCalledWith('http://mock/url', '/tmp/', True)
 
     @responses.activate
-    @patch.object(DownloadManager, 'download_if_needed')
+    @patch.object(DownloadManager, 'retrieve')
     def test_that_it_downloads_the_most_recent_file_url_from_the_os_geoportal(self, mock):
-        responses.add(responses.GET, 'https://geoportal.statistics.gov.uk/geoportal/rest/find/document?searchText=NSPL&f=pjson',
-                      status=200, content_type='application/json',
-                      body=self._mock_geoportal_response(),
-                      match_querystring=True)
-        self._downloader().download()
+        self._downloader_with_mocked_index_json().download()
         mock.assertCalledWith(
             'https://geoportal.statistics.gov.uk/Docs/PostCodes/NSPL_AUG_2014_csv.zip', '/tmp/', True)

--- a/postcodeinfo/settings.py
+++ b/postcodeinfo/settings.py
@@ -174,6 +174,14 @@ if os.path.exists('/dev/log'):
     LOGGING['loggers']['']['handlers'] = ['syslog']
 
 
+# AWS keys
+AWS = {
+    'region_name': os.environ.get('AWS_REGION_NAME', 'eu-west-1'),
+    'access_key_id': os.environ.get('AWS_ACCESS_KEY_ID'),
+    'secret_access_key': os.environ.get('AWS_SECRET_ACCESS_KEY'),
+    's3_bucket_name': os.environ.get('S3_BUCKET_NAME')
+}
+
 # .local.py overrides all the common settings.
 try:
     from .local import *

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+boto==2.38.0
 coverage==3.7.1
 Django==1.8.1
 djangorestframework==3.1.2


### PR DESCRIPTION
so that we can still deploy a new system when Ordnance Survey have removed AddressBase from our FTP site, which they do 21 days after ordering (even though we won't get a new file until the next update - which might be another 2 months away)