### PR TITLE
Prevent Logstash formatter throwing an exception

### DIFF
--- a/postcodeinfo/settings.py
+++ b/postcodeinfo/settings.py
@@ -151,7 +151,7 @@ LOGGING = {
                 '%(message)s')},
 
         'logstash': {
-            '()': 'logstash_formatter.LogstashFormatter'}},
+            '()': 'logstash_formatter.LogstashFormatterV1'}},
 
     'handlers': {
         'console': {


### PR DESCRIPTION
See Sentry event ID e66389bf39554d048e0a95e4a56e73b2 (https://sentry.service.dsd.io/mojds/postcode-info-api/group/41/)