### PR TITLE
Change syslog's format so that it won't include the hostname and timestamp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ ADD ./docker/nginx.conf /etc/nginx/nginx.conf
 # install service files for runit
 ADD ./docker/nginx.service /etc/service/nginx/run
 ADD ./docker/gunicorn.service /etc/service/gunicorn/run
+ADD ./docker/syslog-format.conf /etc/syslog-ng/conf.d/001-format.conf
 
 # Define mountable directories.
 VOLUME ["/var/log/nginx", "/var/log/gunicorn"]

--- a/docker/syslog-format.conf
+++ b/docker/syslog-format.conf
@@ -1,0 +1,6 @@
+template t_rawmsg { template("$MSGHDR$MSG\n"); };
+
+options { chain_hostnames(off); flush_lines(0); use_dns(no); use_fqdn(no);
+          owner("root"); group("adm"); perm(0640); stats_freq(0);
+          bad_hostname("^gconfd$"); file-template(t_rawmsg);
+};


### PR DESCRIPTION
The syslog-ng process inside phusion's baseimage is prepending the current date, time and the hostname. That breaks json logging as now we have to take into account the extra fields when parsing the log as json.
This PR will overwrite phusion's log format by placing a config file in /etc/syslog-ng/conf.d that has a different format that only contains the (json) message.