### PR TITLE
Clearer split_file method + tempdir cleanup

### DIFF
--- a/postcodeinfo/apps/postcode_api/importers/addressbase_basic_importer.py
+++ b/postcodeinfo/apps/postcode_api/importers/addressbase_basic_importer.py
@@ -13,7 +13,7 @@ BRITISH_NATIONAL_GRID = 27700
 def split_file(path, num_lines):
     filename = os.path.basename(path)
     split_dir = tempfile.mkdtemp(prefix=filename + '-')
-    split_file_prefix = "{split_dir}/"
+    split_file_prefix = split_dir + "/"
     runProcess(
         ['/usr/bin/split', '-l', str(num_lines), path, split_file_prefix])
 

--- a/postcodeinfo/apps/postcode_api/importers/addressbase_basic_importer.py
+++ b/postcodeinfo/apps/postcode_api/importers/addressbase_basic_importer.py
@@ -11,9 +11,9 @@ BRITISH_NATIONAL_GRID = 27700
 
 
 def split_file(path, num_lines):
-    split_dir = tempfile.mkdtemp()
-    split_file_prefix = "{split_dir}/{filename}-".format(
-        split_dir=split_dir, filename=os.path.basename(path))
+    filename = os.path.basename(path)
+    split_dir = tempfile.mkdtemp(prefix=filename + '-')
+    split_file_prefix = "{split_dir}/"
     runProcess(
         ['/usr/bin/split', '-l', str(num_lines), path, split_file_prefix])
 


### PR DESCRIPTION
removed the unneccessary lambda from split_file, restored the original filename prefix in the name of split files, and clean-up of temp dirs after import