### PR TITLE
ignore-index import improvement 

### DIFF
--- a/postcodeinfo/apps/postcode_api/management/commands/download_and_import_addressbase_basic.py
+++ b/postcodeinfo/apps/postcode_api/management/commands/download_and_import_addressbase_basic.py
@@ -1,6 +1,8 @@
 import os
 from django.core.management.base import BaseCommand
 
+from index_suppressor import IndexSuppressor
+
 from postcode_api.downloaders.addressbase_basic_downloader \
     import AddressBaseBasicDownloader
 from postcode_api.importers.addressbase_basic_importer \
@@ -28,7 +30,7 @@ class Command(BaseCommand):
                             dest='force',
                             default=False,
                             help='Force download '
-                                 'even if previous download exists')
+                            'even if previous download exists')
 
     def handle(self, *args, **options):
 
@@ -50,11 +52,12 @@ class Command(BaseCommand):
         return downloader.download(destination_dir, force)
 
     def _process_all(self, files):
-        if isinstance(files, list):
-            for filepath in files:
-                self._process(filepath)
-        else:
-            self._process(files)
+        with IndexSuppressor('postcode_api_address'):
+            if isinstance(files, list):
+                for filepath in files:
+                    self._process(filepath)
+            else:
+                self._process(files)
 
     def _process(self, filepath):
         files = ZipExtractor(filepath).unzip_if_needed(

--- a/postcodeinfo/apps/postcode_api/management/commands/import_addressbase_basic.py
+++ b/postcodeinfo/apps/postcode_api/management/commands/import_addressbase_basic.py
@@ -1,6 +1,8 @@
 import os
 
-from multiprocessing import Pool
+from index_suppressor import IndexSuppressor
+
+# from multiprocessing import Pool
 from django.core.management.base import BaseCommand, CommandError
 
 from postcode_api.importers.addressbase_basic_importer \
@@ -14,8 +16,9 @@ class Command(BaseCommand):
         if len(args) == 0:
             raise CommandError('You must specify at least one CSV file')
 
-        p = Pool()
-        p.map(import_csv, args)
+        with IndexSuppressor('postcode_api_address'):
+            for filepath in args:
+                import_csv(filepath)
 
 def import_csv(filename):
     if not os.access(filename, os.R_OK):

--- a/postcodeinfo/lib/index_suppressor.py
+++ b/postcodeinfo/lib/index_suppressor.py
@@ -1,0 +1,39 @@
+from django import db
+import logging
+
+
+class IndexSuppressor(object):
+
+    def __init__(self, tablename, cursor=db.connection.cursor()):
+        self.cursor = cursor
+        self.tablename = tablename
+        self.index_cache = []
+
+    def __enter__(self):
+        logging.debug( '__enter__' )
+        self._drop_indexes()
+
+    def __exit__(self, type, value, tb):
+        logging.debug( '__exit__' )
+        self._restore_indexes()
+
+    def _indexes_on(self, tablename):
+        sql = ("SELECT indexname, indexdef "
+               "from pg_indexes "
+               "where tablename = %s "
+               "and NOT(indexdef like %s)")
+
+        self.cursor.execute(sql, [tablename, '% UNIQUE %'])
+        return self.cursor.fetchall()
+
+    def _drop_indexes(self):
+        for index in self._indexes_on(self.tablename):
+            logging.debug(
+                'dropping index {idx}'.format(idx=index[0]))
+            self.cursor.execute('DROP INDEX {idx}'.format(idx=index[0]))
+            self.index_cache.append(index)
+
+    def _restore_indexes(self):
+        for index in self.index_cache:
+            logging.debug('restoring index {idx}'.format(idx=index[0]))
+            self.cursor.execute(index[1])

--- a/postcodeinfo/lib/index_suppressor.py
+++ b/postcodeinfo/lib/index_suppressor.py
@@ -1,5 +1,20 @@
+# -*- coding: utf-8 -*-
 from django import db
 import logging
+
+
+# We have to do this manually, rather than SET CONSTRAINTS DEFERRED,
+# because:
+# - when we import the whole of AddressBase we have to do it
+#   file-by-file
+# - we can't do it all in one transaction because it will be
+#   way too slow, because:
+# - the \copy cmd, which is by several orders-of-magnitude the fastest
+#   way to get large amts of data into Postgres, messes with the
+#   transaction structure
+# - Postgres behaves better with a manageable transaction size, rather
+#   than trying to do the whole ~30M rows in one
+# So, this context mgr will explicitly
 
 
 class IndexSuppressor(object):
@@ -10,18 +25,23 @@ class IndexSuppressor(object):
         self.index_cache = []
 
     def __enter__(self):
-        logging.debug( '__enter__' )
+        logging.debug('__enter__')
         self._drop_indexes()
 
     def __exit__(self, type, value, tb):
-        logging.debug( '__exit__' )
+        logging.debug('__exit__')
         self._restore_indexes()
 
     def _indexes_on(self, tablename):
+        # NOTE: we have to exclude the UNIQUE indexes
+        # because there are constraints etc which depend on them,
+        # and we dont' get visibility of those relationships
+        # so we can't safely drop-then-recreate them
         sql = ("SELECT indexname, indexdef "
                "from pg_indexes "
                "where tablename = %s "
-               "and NOT(indexdef like %s)")
+               "and NOT(indexdef like %s)"
+               )
 
         self.cursor.execute(sql, [tablename, '% UNIQUE %'])
         return self.cursor.fetchall()
@@ -30,7 +50,9 @@ class IndexSuppressor(object):
         for index in self._indexes_on(self.tablename):
             logging.debug(
                 'dropping index {idx}'.format(idx=index[0]))
-            self.cursor.execute('DROP INDEX {idx}'.format(idx=index[0]))
+
+            self.cursor.execute(
+                'DROP INDEX {idx} CASCADE'.format(idx=index[0]))
             self.index_cache.append(index)
 
     def _restore_indexes(self):


### PR DESCRIPTION
- drop all non-pk indexes on address table before importing, and put them back afterwards
produces a near-order-of-magnitude speed improvement for large (>~3m or so records) in local testing