### PR TITLE
order address objects by primary key in healthcheck.json

### DIFF
--- a/postcodeinfo/apps/postcode_api/views.py
+++ b/postcodeinfo/apps/postcode_api/views.py
@@ -110,5 +110,5 @@ class HealthcheckDotJsonView(MonitoringView):
         return Response(data, status=overall_status)
 
     def is_database_ok(self):
-        address = Address.objects.first()
+        address = Address.objects.order_by('uprn').first()
         return address is not None


### PR DESCRIPTION
the default ordering on Address objects ends up as building number + name, if it's not specified. These columns are not indexed, hence Address.objects.first() is very slow on a 30m-row table!