### PR TITLE
Enable secure cookies, as recommended by django

### DIFF
--- a/postcodeinfo/settings.py
+++ b/postcodeinfo/settings.py
@@ -41,6 +41,7 @@ ALLOWED_HOSTS = os.environ.get('DJANGO_ALLOWED_HOSTS', '').split(',')
 # Enable secure cookies in non-debug mode
 if not DEBUG:
     SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
 
 # Application definition
 

--- a/postcodeinfo/settings.py
+++ b/postcodeinfo/settings.py
@@ -38,6 +38,9 @@ TEMPLATE_DEBUG = True
 
 ALLOWED_HOSTS = os.environ.get('DJANGO_ALLOWED_HOSTS', '').split(',')
 
+# Enable secure cookies in non-debug mode
+if not DEBUG:
+    SESSION_COOKIE_SECURE = True
 
 # Application definition
 


### PR DESCRIPTION
As per [django project's security recommendations](https://docs.djangoproject.com/en/1.8/topics/security/#ssl-https)
Fixes [#87](https://trello.com/c/MtT9yGnN/87-ssl-only-cookie-flag-not-set)