### PR TITLE
Work out where the latest AddressBase file is on each import

### DIFF
--- a/postcodeinfo/apps/postcode_api/downloaders/addressbase_basic.py
+++ b/postcodeinfo/apps/postcode_api/downloaders/addressbase_basic.py
@@ -4,6 +4,7 @@ AddressBase Basic downloader class
 """
 
 import logging
+import ftplib
 import os
 
 from .filesystem import LocalCache
@@ -15,6 +16,7 @@ log = logging.getLogger(__name__)
 
 
 class AddressBaseBasicDownloader(LocalCache, S3Cache, FtpDownloader):
+
     """
     Ordnance Survey remove the files from the download directory after 21 days,
     so we cache the files on Amazon S3 in case we need them after that time.
@@ -31,8 +33,7 @@ class AddressBaseBasicDownloader(LocalCache, S3Cache, FtpDownloader):
             'osmmftp.os.uk',
             os.environ.get('OS_FTP_USERNAME'),
             os.environ.get('OS_FTP_PASSWORD'),
-            path=os.environ.get(
-                'OS_FTP_ORDER_DIR', '../from-os/DCS0001654526/'))
+            path=self.find_dir_with_latest_full_file())
 
     def download(self, dest_dir=None):
         """
@@ -42,3 +43,29 @@ class AddressBaseBasicDownloader(LocalCache, S3Cache, FtpDownloader):
 
         return super(AddressBaseBasicDownloader, self).download(
             '*_csv.zip', dest_dir)
+
+    # Ordnance Survey's update mechanism creates a *new* order number
+    # for every update, so we cannot predict ahead of time what the
+    # directory path will be.
+    # So we work it out as follows:
+    # - the files are all called AddressBase_FULL_YYYY-MM-DD_NNN_csv.zip
+    # - get ALL the files matching that pattern in all the subidrectories
+    # - split into path / filename
+    # - sort by filename
+    # - the last file should be the latest, so use the directory containing it
+    def find_dir_with_latest_full_file(self):
+        # have to create new object rather than exploiting the
+        # inheritance heirarchy, as this method is called during
+        # initialisation
+        tmp_ftp = FtpDownloader('osmmftp.os.uk',
+            os.environ.get('OS_FTP_USERNAME'),
+            os.environ.get('OS_FTP_PASSWORD'),
+            '../from-os/')
+        # full_files = tmp_ftp._list('*/AddressBase_FULL_*')
+        # parsed_file_list = map(lambda fname: {'dir': fname.split(
+        #     '/')[0], 'file': fname.split('/')[-1]}, full_files)
+        # latest = sorted(parsed_file_list, key=lambda key: key['file'])[-1]
+
+        latest = tmp_ftp.find_dir_with_latest_file_matching('*/AddressBase_FULL_*')
+        if latest:
+            return latest['dir']

--- a/postcodeinfo/apps/postcode_api/downloaders/ftp.py
+++ b/postcodeinfo/apps/postcode_api/downloaders/ftp.py
@@ -19,6 +19,7 @@ log = logging.getLogger(__name__)
 
 
 class FtpDownloader(HttpDownloader):
+
     """
     Downloads files from a FTP server
     """
@@ -104,6 +105,23 @@ class FtpDownloader(HttpDownloader):
             if self.path is not None:
                 self._ftp.cwd(self.path)
         return self._ftp
+
+    # NOTE: 'latest' in this case means 'last file when sorted alphabetically'
+    # as the AddressBase file names all contain a timestamp in YYYY-MM-DD
+    # format
+    def find_dir_with_latest_file_matching(self, pattern):
+
+        def parse_relative_path(path):
+            elements = path.split('/')
+            return {'dir': elements[0], 'file': elements[-1]}
+
+        all_matching_files = self._list(pattern)
+        if all_matching_files:
+            parsed_file_list = map(parse_relative_path, all_matching_files)
+            latest = sorted(parsed_file_list,
+                            key=lambda parsed_path: parsed_path['file'])[-1]
+
+            return latest['dir']
 
     def _list(self, pattern):
         files = {}

--- a/postcodeinfo/apps/postcode_api/tests/downloaders/test_addressbase_basic_downloader.py
+++ b/postcodeinfo/apps/postcode_api/tests/downloaders/test_addressbase_basic_downloader.py
@@ -21,6 +21,11 @@ class AddressBaseBasicDownloaderTest(unittest.TestCase):
 
         return mock.patch.dict('os.environ', self.env, clear=True)
 
+    def _mock_find_dir(self):
+        mock_method = mock.MagicMock(return_value='SOMEDIR')
+        AddressBaseBasicDownloader.find_dir_with_latest_full_file = mock_method
+        return mock_method
+
     def test_passes_ftp_credentials(self):
         with mock.patch('ftplib.FTP') as ftp_class, self.mock_env():
             ftp = ftp_class.return_value
@@ -31,6 +36,7 @@ class AddressBaseBasicDownloaderTest(unittest.TestCase):
             ftp.cwd.assertCalledWith(self.env['OS_FTP_ORDER_DIR'])
 
     def test_complains_if_ftp_credentials_not_set(self):
+        self._mock_find_dir()
         logger = 'postcode_api.downloaders.addressbase_basic.log'
         with mock.patch('ftplib.FTP'), \
                 mock.patch(logger) as log, \
@@ -43,8 +49,15 @@ class AddressBaseBasicDownloaderTest(unittest.TestCase):
                 mock.call('OS_FTP_PASSWORD not set!')])
 
     def test_downloads_files_matching_pattern(self):
+        self._mock_find_dir()
         with mock.patch('ftplib.FTP') as ftp_class, self.mock_env():
             ftp = ftp_class.return_value
             AddressBaseBasicDownloader().download()
             self.assertTrue(ftp.dir.called)
             self.assertEqual('*_csv.zip', ftp.dir.call_args[0][0])
+
+    def test_finds_dir_with_latest_full_file(self):
+        self._mock_find_dir()
+        with mock.patch('ftplib.FTP'), self.mock_env():
+            dl = AddressBaseBasicDownloader()
+            self.assertTrue(dl.find_dir_with_latest_full_file.called)

--- a/postcodeinfo/apps/postcode_api/tests/downloaders/test_ftp_downloader.py
+++ b/postcodeinfo/apps/postcode_api/tests/downloaders/test_ftp_downloader.py
@@ -119,3 +119,11 @@ class FTPDownloaderTest(unittest.TestCase):
             downloader._list('*.zip')
             last_modified = downloader.last_modified('1.zip')
             self.assertEqual(dt, last_modified)
+
+    def test_find_dir_with_latest_file_matching(self):
+        mock_files = ['dir-a/file-2014-05-06', 'dir-b/file-2015-06-07', 'dir-c/file-2015-10-29']
+
+        with mock.patch('ftplib.FTP'):
+            downloader = FtpDownloader('host', 'user', 'pass')
+            downloader._list = mock.MagicMock(return_value=mock_files)
+            self.assertEqual( downloader.find_dir_with_latest_file_matching('*/file-*'), 'dir-c' )


### PR DESCRIPTION
AddressBaseDownloader now works out which directory contains the latest full AddressBase file, and imports files from there. 

This is needed because the updates from Ordnance Survey come through as a new, unpredictable, order number each time there is an update - so we cannot know in advance what the directory path to the files will be.