### PR TITLE
Fixed "KeyError: 'last-modified'" when downloading local authorities

### DIFF
--- a/postcodeinfo/apps/postcode_api/downloaders/filesystem.py
+++ b/postcodeinfo/apps/postcode_api/downloaders/filesystem.py
@@ -25,6 +25,7 @@ def last_modified(filename):
 
 
 class LocalCache(object):
+
     """
     Download files unless they already exist locally and are newer than the
     files on the server.
@@ -36,7 +37,10 @@ class LocalCache(object):
         newer than the remote file.
         """
 
-        if exists(dest) and last_modified(dest) >= self.last_modified(src):
-            return dest
+        if exists(dest):
+            dest_mod_date = last_modified(dest)
+            src_mod_date = self.last_modified(src)
+            if src_mod_date and dest_mod_date >= src_mod_date:
+                return dest
 
         return super(LocalCache, self).download_file(src, dest)

--- a/postcodeinfo/apps/postcode_api/downloaders/http.py
+++ b/postcodeinfo/apps/postcode_api/downloaders/http.py
@@ -16,6 +16,7 @@ log = logging.getLogger(__name__)
 
 
 class HttpDownloader(object):
+
     """
     Downloads files from a HTTP server.
     """
@@ -76,7 +77,9 @@ class HttpDownloader(object):
 
         if src is None:
             src = self.url
-        dt = dateparser.parse(self._get_headers(src)['last-modified'])
-        if dt.tzinfo is None:
-            dt = pytz.UTC.localize(dt)
-        return dt
+        hdrs = self._get_headers(src)
+        if hdrs.get('last-modified'):
+            dt = dateparser.parse(hdrs['last-modified'])
+            if dt.tzinfo is None:
+                dt = pytz.UTC.localize(dt)
+            return dt

--- a/postcodeinfo/apps/postcode_api/downloaders/local_authorities.py
+++ b/postcodeinfo/apps/postcode_api/downloaders/local_authorities.py
@@ -3,6 +3,8 @@
 Local Authorities downloader class
 """
 
+import os
+
 from .filesystem import LocalCache
 from .http import HttpDownloader
 from .s3 import S3Cache
@@ -10,6 +12,13 @@ from .s3 import S3Cache
 
 class LocalAuthoritiesDownloader(LocalCache, S3Cache, HttpDownloader):
 
+    def _authoritative_url(self):
+        default_url = 'http://opendatacommunities-graphs.publishmydata.com'\
+                      '?graph-uri=http://opendatacommunities.org/graph/dev'\
+                      '-local-authorities'
+        
+        return os.environ.get('LOCAL_AUTHORITIES_DUMP_URL') or default_url
+
     def __init__(self):
         super(LocalAuthoritiesDownloader, self).__init__(
-            'http://opendatacommunities.org/data/dev-local-authorities/dump')
+            self._authoritative_url())

--- a/postcodeinfo/apps/postcode_api/tests/downloaders/test_local_authorities_downloader.py
+++ b/postcodeinfo/apps/postcode_api/tests/downloaders/test_local_authorities_downloader.py
@@ -6,7 +6,14 @@ from postcode_api.downloaders import LocalAuthoritiesDownloader
 
 class LocalAuthoritiesDownloaderTest(unittest.TestCase):
 
-    def test_url(self):
+    def test_url_is_the_authoritative_url(self):
         downloader = LocalAuthoritiesDownloader()
-        url = 'http://opendatacommunities.org/data/dev-local-authorities/dump'
+        url = downloader._authoritative_url()
         self.assertEqual(url, downloader.url)
+
+    def test_that_the_default_url_can_be_overridden_with_an_env_var(self):
+        mock_env = {'LOCAL_AUTHORITIES_DUMP_URL': 'blah'}
+        with mock.patch.dict('os.environ', mock_env):
+            downloader = LocalAuthoritiesDownloader()
+            self.assertEqual('blah', downloader.url)
+        


### PR DESCRIPTION
Caused by DCLG moving their datafile without a redirect.
It's now on publishmydata.com, a commercial service that adds more layers of redirect, and doesn't provide a last-modified header.