### PR TITLE
Fixed crash when downloading LocalAuthorities if the file doesn't exist on s3

### DIFF
--- a/postcodeinfo/apps/postcode_api/downloaders/filesystem.py
+++ b/postcodeinfo/apps/postcode_api/downloaders/filesystem.py
@@ -40,7 +40,9 @@ class LocalCache(object):
         if exists(dest):
             dest_mod_date = last_modified(dest)
             src_mod_date = self.last_modified(src)
-            if src_mod_date and dest_mod_date >= src_mod_date:
+
+            if (src_mod_date and dest_mod_date
+                    and dest_mod_date >= src_mod_date):
                 return dest
 
         return super(LocalCache, self).download_file(src, dest)

--- a/postcodeinfo/apps/postcode_api/downloaders/http.py
+++ b/postcodeinfo/apps/postcode_api/downloaders/http.py
@@ -44,6 +44,8 @@ class HttpDownloader(object):
         """
 
         def download():
+            log.debug 'downloading {src} to {dest}'.format(
+                src=src, dest=dest)
             data = requests.get(src, stream=True)
             with open(dest, 'wb') as f:
                 for i, chunk in enumerate(data.iter_content(self.chunk_size)):

--- a/postcodeinfo/apps/postcode_api/downloaders/http.py
+++ b/postcodeinfo/apps/postcode_api/downloaders/http.py
@@ -44,8 +44,8 @@ class HttpDownloader(object):
         """
 
         def download():
-            log.debug 'downloading {src} to {dest}'.format(
-                src=src, dest=dest)
+            log.debug( 'downloading {src} to {dest}'.format(
+                src=src, dest=dest) )
             data = requests.get(src, stream=True)
             with open(dest, 'wb') as f:
                 for i, chunk in enumerate(data.iter_content(self.chunk_size)):

--- a/postcodeinfo/apps/postcode_api/downloaders/local_authorities.py
+++ b/postcodeinfo/apps/postcode_api/downloaders/local_authorities.py
@@ -13,10 +13,10 @@ from .s3 import S3Cache
 class LocalAuthoritiesDownloader(LocalCache, S3Cache, HttpDownloader):
 
     def _authoritative_url(self):
-        default_url = 'http://opendatacommunities-graphs.publishmydata.com'\
-                      '?graph-uri=http://opendatacommunities.org/graph/dev'\
-                      '-local-authorities'
-        
+        default_url = 'http://opendatacommunities.org/downloads/graph?uri='\
+                      'http://opendatacommunities.org/graph/dev-'\
+                      'local-authorities'
+
         return os.environ.get('LOCAL_AUTHORITIES_DUMP_URL') or default_url
 
     def __init__(self):

--- a/postcodeinfo/apps/postcode_api/tests/downloaders/test_s3_cache.py
+++ b/postcodeinfo/apps/postcode_api/tests/downloaders/test_s3_cache.py
@@ -56,3 +56,9 @@ class S3CacheTest(unittest.TestCase):
                 downloader.download('/tmp')
 
                 self.assertEqual(use_local, get.called)
+
+    def test_that_an_empty_last_modified_does_not_cause_a_crash(self):
+        mock_obj = mock.MagicMock('mock object', last_modified=None)
+        cache = S3Cache()
+        last_mod = cache._last_modified_with_timezone(mock_obj)
+        self.assertEqual(last_mod, None)


### PR DESCRIPTION
also moved the authoritative URL for the LocalAuthorities dataset back to opendatacommunities.org, as the source website seems to have moved back off publishmydata.com