### PR TITLE
fixed redundant double-dereference of ['dir'] key 

### DIFF
--- a/postcodeinfo/apps/postcode_api/downloaders/addressbase_basic.py
+++ b/postcodeinfo/apps/postcode_api/downloaders/addressbase_basic.py
@@ -61,11 +61,5 @@ class AddressBaseBasicDownloader(LocalCache, S3Cache, FtpDownloader):
             os.environ.get('OS_FTP_USERNAME'),
             os.environ.get('OS_FTP_PASSWORD'),
             '../from-os/')
-        # full_files = tmp_ftp._list('*/AddressBase_FULL_*')
-        # parsed_file_list = map(lambda fname: {'dir': fname.split(
-        #     '/')[0], 'file': fname.split('/')[-1]}, full_files)
-        # latest = sorted(parsed_file_list, key=lambda key: key['file'])[-1]
 
-        latest = tmp_ftp.find_dir_with_latest_file_matching('*/AddressBase_FULL_*')
-        if latest:
-            return latest['dir']
+        return tmp_ftp.find_dir_with_latest_file_matching('*/AddressBase_FULL_*')


### PR DESCRIPTION
...when trying to download addressbase_basic from FTP site.

As this error only occurred when actually downloading from Ordnance Survey with multiple available order directories, and FTP doesn't work over our internal office wifi connection (something something passive mode) we only found this when running in AWS - e.g. on staging / prod. We should probably have a think about how to handle that in our tests.