### PR TITLE
Fixed root/relative path issue on addressbase import

### DIFF
--- a/postcodeinfo/apps/postcode_api/downloaders/addressbase_basic.py
+++ b/postcodeinfo/apps/postcode_api/downloaders/addressbase_basic.py
@@ -57,9 +57,12 @@ class AddressBaseBasicDownloader(LocalCache, S3Cache, FtpDownloader):
         # have to create new object rather than exploiting the
         # inheritance heirarchy, as this method is called during
         # initialisation
+        root_path = '../from-os/'
         tmp_ftp = FtpDownloader('osmmftp.os.uk',
             os.environ.get('OS_FTP_USERNAME'),
             os.environ.get('OS_FTP_PASSWORD'),
-            '../from-os/')
+            root_path)
 
-        return tmp_ftp.find_dir_with_latest_file_matching('*/AddressBase_FULL_*')
+        latest_dir = tmp_ftp.find_dir_with_latest_file_matching('*/AddressBase_FULL_*')
+        if latest_dir:
+            return root_path + latest_dir


### PR DESCRIPTION
This was causing ./manage.py download_addressbase_basic to fail with the error:
"error_perm: 550 DCS0001772041: No such file or directory."

(note: this task can only be run outside the MoJ network, as for some
reason FTP doesn't work inside it)