### PR TITLE
fixes an inconsistency in the arguments for http & ftp downloaders

### DIFF
--- a/postcodeinfo/apps/postcode_api/downloaders/download_manager.py
+++ b/postcodeinfo/apps/postcode_api/downloaders/download_manager.py
@@ -61,7 +61,7 @@ class DownloadManager(object):
 
     def download_and_put_to_cache(self, cache_key):
         log.info("not in cache - downloading")
-        downloaded_paths = self.downloader.download(self.destination_dir)
+        downloaded_paths = self.downloader.download(pattern=cache_key, dest_dir=self.destination_dir)
         for downloaded_path in downloaded_paths:
             log.info("putting to cache with key {key}".format(key=cache_key))
             self.caching_strategy.put(cache_key, downloaded_path)

--- a/postcodeinfo/apps/postcode_api/downloaders/ftp.py
+++ b/postcodeinfo/apps/postcode_api/downloaders/ftp.py
@@ -32,14 +32,13 @@ class FtpDownloader(HttpDownloader):
         self._ftp = None
         self._headers = {}
 
-    def download(self, pattern, dest_dir=None):
+    def download(self, *args, **kwargs):
         """
         Execute the download.
         Returns a list of downloaded files.
         """
-
-        if dest_dir is None:
-            dest_dir = tempfile.mkdtemp(prefix=self.__class__.__name__)
+        dest_dir = kwargs.pop('dest_dir', tempfile.mkdtemp(prefix=self.__class__.__name__))
+        pattern = kwargs.pop('pattern')
 
         files = self.list(pattern)
         log.debug('%i files matching %s' % (len(files), pattern))

--- a/postcodeinfo/apps/postcode_api/downloaders/http.py
+++ b/postcodeinfo/apps/postcode_api/downloaders/http.py
@@ -27,17 +27,15 @@ class HttpDownloader(object):
         self.chunk_size = int(os.environ.get('DOWNLOAD_CHUNK_SIZE', 4192))
         self._headers = {}
 
-    def download(self, dest_dir=None):
+    def download(self, *args, **kwargs):
         """
         Execute the download.
         Returns a list of downloaded files.
         """
-
-        if dest_dir is None:
-            dest_dir = tempfile.mkdtemp(prefix=self.__class__.__name__)
-
-        dest = os.path.join(dest_dir, self.url.split('/')[-1])
-        return [self.download_file(self.url, dest)]
+        dest_dir = kwargs.pop('dest_dir', tempfile.mkdtemp(prefix=self.__class__.__name__))
+        pattern = kwargs.pop('pattern', self.url)
+        dest = os.path.join(dest_dir, pattern.split('/')[-1])
+        return [self.download_file(pattern, dest)]
 
     def download_file(self, src, dest):
         """

--- a/postcodeinfo/apps/postcode_api/tests/downloaders/test_ftp_downloader.py
+++ b/postcodeinfo/apps/postcode_api/tests/downloaders/test_ftp_downloader.py
@@ -74,7 +74,7 @@ class FTPDownloaderTest(unittest.TestCase):
             mkdtemp.return_value = test_dir
 
             downloader = FtpDownloader('host', 'user', 'pass')
-            files = downloader.download(pattern)
+            files = downloader.download(pattern=pattern, dest_dir=test_dir)
 
             filename = lambda i: '{0}/{1}.zip'.format(test_dir, i)
 

--- a/postcodeinfo/apps/postcode_api/tests/downloaders/test_http_downloader.py
+++ b/postcodeinfo/apps/postcode_api/tests/downloaders/test_http_downloader.py
@@ -44,9 +44,10 @@ class HttpDownloaderTest(unittest.TestCase):
             mkdtemp.return_value = test_dir
 
             for url, dest_dir, path in [
-                    (test_url, None, '%s/%s' % (test_dir, test_filename)),
+                    (test_url, test_dir, '%s/%s' % (test_dir, test_filename)),
                     (test_url, '/tmp', '/tmp/%s' % test_filename)]:
-                HttpDownloader(url).download(dest_dir)
+
+                HttpDownloader(url).download(pattern=test_url, dest_dir=dest_dir)
                 mock_open.assert_called_with(path, 'wb')
 
     def test_download_file(self):
@@ -60,7 +61,7 @@ class HttpDownloaderTest(unittest.TestCase):
             get.return_value.iter_content.return_value = iter(fake_data)
             url = 'http://example.com/dummy_url'
 
-            filename = HttpDownloader(url).download('/tmp')
+            filename = HttpDownloader(url).download(dest_dir='/tmp')
 
             self.assertEqual(['/tmp/dummy_url'], filename)
             self.mocked_file().write.assert_has_calls(


### PR DESCRIPTION
the arguments for download() in the http & ftp downloaders were not consistent, leading to persistent bugs. Refactored them both to use keyword arguments.