### PR TITLE
Partition address table to speed up partial searches

### DIFF
--- a/postcodeinfo/apps/postcode_api/migrations/0016_partition_address_table.py
+++ b/postcodeinfo/apps/postcode_api/migrations/0016_partition_address_table.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import string
+import time
+
+from django.contrib.gis.geos import Point
+from django.db import migrations
+
+from postcode_api.models import Address
+
+
+def partition_address_table(apps, schema_editor):
+    Address.architect.partition.get_partition().prepare()
+
+    # the partition tables are only lazily created on-demand, so let's
+    # aggressively pre-create them here by inserting & deleting an address
+    # with each possible prefix
+    dummy_date = time.strftime("%Y-%m-%d")
+    all_possible_prefixes = string.ascii_lowercase + string.digits
+    for first_char in all_possible_prefixes:
+        tmp_address = Address.objects.create(postcode_index=first_char*6,
+                                             point=Point(123, 123),
+                                             rpc=012345,
+                                             uprn=1234567890,
+                                             start_date=dummy_date,
+                                             last_update_date=dummy_date,
+                                             entry_date=dummy_date,
+                                             process_date=dummy_date
+                                             )
+        tmp_address.delete()
+        sql = """
+            INSERT INTO postcode_api_address_{suffix}
+            SELECT * FROM postcode_api_address
+            WHERE postcode_index LIKE %s;
+        """.format(suffix=first_char)
+        print "insert-selecting into partition {char}".format(char=first_char)
+        schema_editor.execute(
+            sql, ['{first_char}%'.format(first_char=first_char)])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('postcode_api', '0015_add_ni_local_authorities'),
+    ]
+
+    operations = [
+        migrations.RunPython(partition_address_table),
+    ]

--- a/postcodeinfo/apps/postcode_api/migrations/0017_allow_null_entry_date.py
+++ b/postcodeinfo/apps/postcode_api/migrations/0017_allow_null_entry_date.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('postcode_api', '0016_partition_address_table'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='address',
+            name='entry_date',
+            field=models.DateField(null=True),
+        ),
+    ]

--- a/postcodeinfo/apps/postcode_api/migrations/0018_allow_null_process_date.py
+++ b/postcodeinfo/apps/postcode_api/migrations/0018_allow_null_process_date.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('postcode_api', '0017_allow_null_entry_date'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='address',
+            name='process_date',
+            field=models.DateField(null=True),
+        ),
+    ]

--- a/postcodeinfo/apps/postcode_api/models.py
+++ b/postcodeinfo/apps/postcode_api/models.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import architect
+
 from django.contrib.gis.db import models
 from django.db.models import Count, signals
 from django.dispatch import receiver
@@ -21,7 +23,7 @@ class AddressManager(models.GeoManager):
             signals.pre_save.send(sender=Address, instance=obj)
         super(AddressManager, self).bulk_create(objs, batch_size=batch_size)
 
-
+@architect.install('partition', type='range', subtype='string_firstchars', constraint='1', column='postcode_index')
 class Address(models.Model):
     uprn = models.CharField(max_length=12, primary_key=True)
     os_address_toid = models.CharField(max_length=20, default='', blank=True)

--- a/postcodeinfo/settings.py
+++ b/postcodeinfo/settings.py
@@ -154,7 +154,7 @@ LOGGING = {
     'formatters': {
         'verbose': {
             'format': (
-                '%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d'
+                '%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d '
                 '%(message)s')},
 
         'logstash': {

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ six==1.9.0
 SPARQLWrapper==1.6.4
 titlecase==0.7.2
 wheel==0.24.0
+architect==0.5.3

--- a/scripts/addressbase_import.sh
+++ b/scripts/addressbase_import.sh
@@ -137,25 +137,6 @@ function cleanup_tables_sql {
             WHERE postcode_index LIKE '$first_char%';"
     done
 
-  # echo "
-  #   SELECT 'removing tmp import table' AS status;
-  #   DROP TABLE $TEMP_TABLE_NAME;
-
-  #   SELECT 'copying indexes onto offline table' AS status;
-  #   `copy_indexes_sql`
-
-  #   SELECT 'renaming tables' AS status;
-  #   SELECT 'dropping $PREV_LIVE_TABLE_NAME' AS status;
-  #   DROP TABLE IF EXISTS $PREV_LIVE_TABLE_NAME;
-  #   SELECT 'renaming $LIVE_TABLE_NAME to $PREV_LIVE_TABLE_NAME' AS status;
-  #   ALTER TABLE $LIVE_TABLE_NAME RENAME TO $PREV_LIVE_TABLE_NAME;
-  #   $(rename_indexes_sql $LIVE_TABLE_NAME $LIVE_TABLE_NAME $PREV_LIVE_TABLE_NAME)
-
-  #   SELECT 'renaming $OFFLINE_TABLE_NAME to $LIVE_TABLE_NAME' AS status;
-  #   ALTER TABLE $OFFLINE_TABLE_NAME RENAME TO $LIVE_TABLE_NAME;
-  # "
-}
-
 
 # Main processing actually starts here
 if [ $# -eq 0 ]

--- a/scripts/addressbase_import.sh
+++ b/scripts/addressbase_import.sh
@@ -126,6 +126,37 @@ function convert_data_sql {
 }
 
 
+function cleanup_tables_sql {
+    for first_char in {a..z} {0..9}
+    do
+      echo "SELECT 'deleting from ${LIVE_TABLE_NAME}_${first_char}' AS status;"
+      echo "TRUNCATE TABLE ${LIVE_TABLE_NAME}_${first_char};"
+      echo "SELECT 'inserting into ${LIVE_TABLE_NAME}_${first_char}' AS status;"
+      echo "INSERT INTO ${LIVE_TABLE_NAME}_${first_char}
+            SELECT * FROM $OFFLINE_TABLE_NAME
+            WHERE postcode_index LIKE '$first_char%';"
+    done
+
+  # echo "
+  #   SELECT 'removing tmp import table' AS status;
+  #   DROP TABLE $TEMP_TABLE_NAME;
+
+  #   SELECT 'copying indexes onto offline table' AS status;
+  #   `copy_indexes_sql`
+
+  #   SELECT 'renaming tables' AS status;
+  #   SELECT 'dropping $PREV_LIVE_TABLE_NAME' AS status;
+  #   DROP TABLE IF EXISTS $PREV_LIVE_TABLE_NAME;
+  #   SELECT 'renaming $LIVE_TABLE_NAME to $PREV_LIVE_TABLE_NAME' AS status;
+  #   ALTER TABLE $LIVE_TABLE_NAME RENAME TO $PREV_LIVE_TABLE_NAME;
+  #   $(rename_indexes_sql $LIVE_TABLE_NAME $LIVE_TABLE_NAME $PREV_LIVE_TABLE_NAME)
+
+  #   SELECT 'renaming $OFFLINE_TABLE_NAME to $LIVE_TABLE_NAME' AS status;
+  #   ALTER TABLE $OFFLINE_TABLE_NAME RENAME TO $LIVE_TABLE_NAME;
+  # "
+}
+
+
 # Main processing actually starts here
 if [ $# -eq 0 ]
   then 

--- a/scripts/addressbase_import.sh
+++ b/scripts/addressbase_import.sh
@@ -136,7 +136,7 @@ function cleanup_tables_sql {
             SELECT * FROM $OFFLINE_TABLE_NAME
             WHERE postcode_index LIKE '$first_char%';"
     done
-
+}
 
 # Main processing actually starts here
 if [ $# -eq 0 ]


### PR DESCRIPTION
fixes #124 - partial postcode searches very slow - and also fixes identification of the appropriate country on partial searches, by partitioning the address table based on first character of the postcode_index, and calculating partial centroids entirely in the database