### PR TITLE
Separate population of partition tables from creation

### DIFF
--- a/postcodeinfo/apps/postcode_api/migrations/0016_partition_address_table.py
+++ b/postcodeinfo/apps/postcode_api/migrations/0016_partition_address_table.py
@@ -29,14 +29,6 @@ def partition_address_table(apps, schema_editor):
                                              process_date=dummy_date
                                              )
         tmp_address.delete()
-        sql = """
-            INSERT INTO postcode_api_address_{suffix}
-            SELECT * FROM postcode_api_address
-            WHERE postcode_index LIKE %s;
-        """.format(suffix=first_char)
-        print "insert-selecting into partition {char}".format(char=first_char)
-        schema_editor.execute(
-            sql, ['{first_char}%'.format(first_char=first_char)])
 
 
 class Migration(migrations.Migration):

--- a/postcodeinfo/apps/postcode_api/migrations/0019_populate_partition_tables.py
+++ b/postcodeinfo/apps/postcode_api/migrations/0019_populate_partition_tables.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import string
+
+from django.db import migrations
+
+from postcode_api.models import Address
+
+
+def partition_address_table(apps, schema_editor):
+    Address.architect.partition.get_partition().prepare()
+
+    # the partition tables are only lazily created on-demand, so let's
+    # aggressively pre-create them here by inserting & deleting an address
+    # with each possible prefix
+    all_possible_prefixes = string.ascii_lowercase + string.digits
+    for first_char in all_possible_prefixes:
+
+        sql = """
+            TRUNCATE TABLE postcode_api_address_{suffix};
+
+            INSERT INTO postcode_api_address_{suffix}
+            SELECT * FROM postcode_api_address
+            WHERE postcode_index LIKE %s;
+        """.format(suffix=first_char)
+        print "insert-selecting into partition {char}".format(char=first_char)
+        schema_editor.execute(
+            sql, ['{first_char}%'.format(first_char=first_char)])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('postcode_api', '0018_allow_null_process_date'),
+    ]
+
+    operations = [
+        migrations.RunPython(partition_address_table),
+    ]


### PR DESCRIPTION
The previous all-in-one migration was timing out after several hours runtime on production, with a fully-populated database. This commit separates out the population of the tables to a separate migration.