### PR TITLE
Fix local authority import multiple files issue

### DIFF
--- a/postcodeinfo/apps/postcode_api/importers/psql_import_adapter.py
+++ b/postcodeinfo/apps/postcode_api/importers/psql_import_adapter.py
@@ -14,7 +14,7 @@ def runProcess(exe, **kwargs):
 
     while p.poll() is None:
         line = p.stdout.readline()
-        logging.debug(line.rstrip())
+        logging.info(line.rstrip())
         
 
 class PSQLImportAdapter(object):

--- a/postcodeinfo/apps/postcode_api/management/commands/download_and_import_local_authorities.py
+++ b/postcodeinfo/apps/postcode_api/management/commands/download_and_import_local_authorities.py
@@ -24,17 +24,10 @@ class Command(BaseCommand):
 
         downloaded_files = self._download(options['destination_dir'])
         if downloaded_files:
-            self._process_all(downloaded_files)
-        else:
-            print 'nothing downloaded - nothing to import'
-
-    def _process_all(self, files):
-        if isinstance(files, list):
-            for path in flatten(files):
+            for path in flatten([downloaded_files]):
                 self._import(path)
         else:
-            self._import(path)
-
+            print 'nothing downloaded - nothing to import'
 
     def _download(self, destination_dir):
         print 'downloading'

--- a/postcodeinfo/apps/postcode_api/management/commands/download_and_import_local_authorities.py
+++ b/postcodeinfo/apps/postcode_api/management/commands/download_and_import_local_authorities.py
@@ -4,7 +4,7 @@ from django.core.management.base import BaseCommand
 from postcode_api.downloaders import LocalAuthoritiesDownloader
 from postcode_api.importers.local_authorities_importer \
     import LocalAuthoritiesImporter
-from postcode_api.utils import ZipExtractor
+from postcode_api.utils import flatten
 
 
 class Command(BaseCommand):
@@ -24,10 +24,17 @@ class Command(BaseCommand):
 
         downloaded_files = self._download(options['destination_dir'])
         if downloaded_files:
-            for path in downloaded_files:
-                self._import(path)
+            self._process_all(downloaded_files)
         else:
             print 'nothing downloaded - nothing to import'
+
+    def _process_all(self, files):
+        if isinstance(files, list):
+            for path in flatten(files):
+                self._import(path)
+        else:
+            self._import(path)
+
 
     def _download(self, destination_dir):
         print 'downloading'
@@ -35,6 +42,6 @@ class Command(BaseCommand):
         return downloader.download(destination_dir)
 
     def _import(self, downloaded_file):
-        print 'importing %{file}'.format(file=downloaded_file)
+        print 'importing {file}'.format(file=downloaded_file)
         importer = LocalAuthoritiesImporter()
         importer.import_local_authorities(downloaded_file)

--- a/postcodeinfo/apps/postcode_api/management/commands/write_new_cache_version.py
+++ b/postcodeinfo/apps/postcode_api/management/commands/write_new_cache_version.py
@@ -2,7 +2,6 @@ from django.core.management.base import BaseCommand
 
 from postcode_api.models import CacheVersion
 
-
 class Command(BaseCommand):
     args = 'latest_filename'
 

--- a/postcodeinfo/apps/postcode_api/models.py
+++ b/postcodeinfo/apps/postcode_api/models.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import architect
-
 from django.contrib.gis.db import models
 from django.contrib.gis.geos import GEOSGeometry
 from django.db import connection

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,4 +27,3 @@ six==1.9.0
 SPARQLWrapper==1.6.4
 titlecase==0.7.2
 wheel==0.24.0
-architect==0.5.3


### PR DESCRIPTION
It's possible for the downloader to return multiple matching files, and this was causing the download_and_import_local_authorities command to fail. This patch fixes the issue by detecting a list of files and looping round it, importing each one.