### PR TITLE
Add ping.json location with custom host header

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -94,6 +94,14 @@ server {
         proxy_pass  http://gunicorn;
     }
 
+    location /ping.json {
+        proxy_set_header   Host                 pinghost.dsd.io;
+        proxy_set_header   X-Real-IP            $remote_addr;
+        proxy_set_header   X-Forwarded-For      $proxy_add_x_forwarded_for;
+        proxy_redirect     off;
+        proxy_pass  http://gunicorn;
+    }
+
     location /static/ {
         alias /srv/postcodeinfo/postcodeinfo/static/;
     }


### PR DESCRIPTION
This will allow use of an HTTP healthcheck from AWS ELBs on ping.json
without getting a 400 response from guinicorn due to the ELB using its
own IP as the host header