### PR TITLE
Mark the repo as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Code Climate](https://codeclimate.com/github/ministryofjustice/postcodeinfo/badges/gpa.svg)](https://codeclimate.com/github/ministryofjustice/postcodeinfo)
 
+*Deprecated*: Please do not use this for new MoJ projects. The recommendation is to use [OS Places](https://developer.ordnancesurvey.co.uk/os-places-api) unless it unless it explicitly doesn't support the thing we want (and, even then, consider if that's necessary). Contact the cloud platform team to find out how to access our MoJ account.
+
 
 REST API for UK Postcode information 
 ====================================


### PR DESCRIPTION
## What

Suggest that people not to use it for new projects.

## Why

People keep asking me why we're not using it for our new project :)

I understand that we've decided not to invest more in postcodeinfo, because it's probably more cost effective to use a commercial product than to pay people to maintain the software and running instances of it.

If that's the case we should probably make it official.

## Who should review

@SteveMarshall or @kerin should probably check my explanation and understanding is correct
